### PR TITLE
correct semver version string to only use digits

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-ros",
-    "version": "0.4.0-alpha",
+    "version": "0.4.0",
     "publisher": "ms-riot",
     "engines": {
         "vscode": "^1.26.0"


### PR DESCRIPTION
`vsce` only supports semver strings with digits, `0.4.0-alpha` fails at `vsce publish`

remove pre-release flag so it becomes `0.4.0`