### PR TITLE
update extension dependencies

### DIFF
--- a/languages/ros.msg.configuration.json
+++ b/languages/ros.msg.configuration.json
@@ -1,0 +1,14 @@
+{
+    "comments": {
+        "lineComment": "#"
+    },
+    "brackets": [
+        ["[", "]"]
+    ],
+    "autoClosingPairs": [
+        { "open": "[", "close": "]", "notIn": ["comment"] }
+    ],
+    "surroundingPairs": [
+        ["[", "]"]
+    ]
+}

--- a/languages/syntaxes/ros.msg.tmLanguage.json
+++ b/languages/syntaxes/ros.msg.tmLanguage.json
@@ -1,0 +1,115 @@
+{
+    "name": "ros.msg",
+    "scopeName": "source.ros.msg",
+    "fileTypes": [
+        "action",
+        "msg",
+        "srv"
+    ],
+    "patterns": [
+        {
+            "name": "meta.field.msg",
+            "begin": "^\\s*(string)\\b",
+            "beginCaptures": {
+                "1": {
+                    "name": "storage.type.msg"
+                }
+            },
+            "end": "$",
+            "patterns": [
+                {
+                    "begin": "=",
+                    "end": "$",
+                    "contentName": "string.unquoted.msg"
+                },
+                {
+                    "include": "#field"
+                }
+            ]
+        },
+        {
+            "name": "meta.field.msg",
+            "begin": "^\\s*([/\\w]+)\\b",
+            "beginCaptures": {
+                "1": {
+                    "patterns": [
+                        {
+                            "include": "#types"
+                        }
+                    ]
+                }
+            },
+            "end": "$",
+            "patterns": [
+                {
+                    "include": "#field"
+                }
+            ]
+        },
+        {
+            "include": "#comments"
+        }
+    ],
+    "repository": {
+        "field": {
+            "patterns": [
+                {
+                    "include": "#comments"
+                },
+                {
+                    "include": "#identifier"
+                },
+                {
+                    "include": "#numeric-constant"
+                },
+                {
+                    "begin": "=",
+                    "end": "$",
+                    "patterns": [
+                        {
+                            "include": "#boolean-constant"
+                        },
+                        {
+                            "include": "#numeric-constant"
+                        },
+                        {
+                            "include": "#comments"
+                        }
+                    ]
+                }
+            ]
+        },
+        "comments": {
+            "match": "#.*",
+            "name": "comment.line.number-sign.msg"
+        },
+        "types": {
+            "patterns": [
+                {
+                    "match": "\\b(bool|u?int(8|16|32|64)|float(32|64)|string|time|duration)\\b",
+                    "name": "storage.type.msg"
+                },
+                {
+                    "match": "\\b(byte|char)\\b",
+                    "name": "invalid.deprecated.msg"
+                },
+                {
+                    "match": "\\b[a-zA-Z]\\w*(\\/[a-zA-Z]\\w*)?\\b",
+                    "name": "support.class"
+                }
+            ]
+        },
+        "identifier": {
+            "match": "\\b[a-zA-Z]\\w+\\b",
+            "name": "variable.parameter"
+        },
+        "boolean-constant": {
+            "match": "\\b(True|False)\\b",
+            "name": "constant.language.msg"
+        },
+        "numeric-constant": {
+            "match": "\\b[+-]?[0-9]*\\.?[0-9]+([eE][+-]?\\d+)?\\b",
+            "name": "constant.numeric.msg"
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -184,6 +184,25 @@
                 "extensions": [
                     "rviz"
                 ]
+            },
+            {
+                "id": "ros.msg",
+                "aliases": [
+                    "ROS Message"
+                ],
+                "extensions": [
+                    ".action",
+                    ".msg",
+                    ".srv"
+                ],
+                "configuration": "./languages/ros.msg.configuration.json"
+            }
+        ],
+        "grammars": [
+            {
+                "language": "ros.msg",
+                "scopeName": "source.ros.msg",
+                "path": "./languages/syntaxes/ros.msg.tmLanguage.json"
             }
         ],
         "menus": {
@@ -231,8 +250,5 @@
         "mocha": "^6.1.4",
         "typescript": "^3.4.3",
         "vscode": "^1.1.33"
-    },
-    "extensionDependencies": [
-        "ajshort.msg"
-    ]
+    }
 }

--- a/package.json
+++ b/package.json
@@ -250,5 +250,9 @@
         "mocha": "^6.1.4",
         "typescript": "^3.4.3",
         "vscode": "^1.1.33"
-    }
+    },
+    "extensionDependencies": [
+        "ms-python.python",
+        "ms-vscode.cpptools"
+    ]
 }


### PR DESCRIPTION
update extension dependencies:
- ROS Message language support for `.msg`, `.srv`, and `.action` files was previously hosted in [`vscode-msg`](https://github.com/ajshort/vscode-msg). Merge into `vscode-ros`
- `vscode-ros` updates configurations referenced by `python` and `cpptools` extensions, declare dependencies on those extensions