### PR TITLE
Update cpp property per platform

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-ros",
-    "version": "0.4.5",
+    "version": "0.4.6-dev",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-ros",
-    "version": "0.4.5",
+    "version": "0.4.6-dev",
     "publisher": "ms-iot",
     "engines": {
         "vscode": "^1.26.0"

--- a/src/ros/build-env-utils.ts
+++ b/src/ros/build-env-utils.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Andrew Short. All rights reserved.
 // Licensed under the MIT License.
 
-import * as os from "os";
 import * as path from "path";
 import * as vscode from "vscode";
 
@@ -84,7 +83,7 @@ async function updateCppPropertiesInternal(): Promise<void> {
                     databaseFilename: "",
                     limitSymbolsToIncludedHeaders: true,
                 },
-                includePath: [...includes],
+                includePath: includes,
                 name: "ROS",
             },
         ],

--- a/src/ros/build-env-utils.ts
+++ b/src/ros/build-env-utils.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Andrew Short. All rights reserved.
 // Licensed under the MIT License.
 
+import * as os from "os";
 import * as path from "path";
 import * as vscode from "vscode";
 
@@ -67,15 +68,23 @@ async function updateCppPropertiesInternal(): Promise<void> {
         });
     }));
 
-    await pfs.writeFile(filename, JSON.stringify({
+    let platform: string = os.platform();
+    let c_cpp_properties: any = {
         configurations: [
             {
                 browse: { databaseFilename: "", limitSymbolsToIncludedHeaders: true },
-                includePath: [...includes, "/usr/include"],
-                name: "Linux",
+                includePath: [...includes],
+                name: "Windows",
             },
         ],
-    }, undefined, 2));
+    };
+
+    if (platform != "win32") {
+        c_cpp_properties.configurations[0].name = "Linux"
+        c_cpp_properties.configurations[0].includePath.push("/usr/include");
+    }
+
+    await pfs.writeFile(filename, JSON.stringify(c_cpp_properties, undefined, 2));
 }
 
 export function updatePythonPath(context: vscode.ExtensionContext) {


### PR DESCRIPTION
On Windows, the cpp property should be using the following settings:
```
"name": "Windows",
"intelliSenseMode": "msvc-x64",
```

Also, we should not add `/usr/include` when it is Windows.
(This fix should be able to address part of #72.)