### PR TITLE
[ros.showCoreStatus] Fix trim() exception when processing parameters

### DIFF
--- a/src/ros/core-monitor/main.ts
+++ b/src/ros/core-monitor/main.ts
@@ -23,7 +23,7 @@ function generateParemetersUnorderedList(parameters) {
             li.appendChild(generateParemetersUnorderedList(parameters[p]));
         }
         else {
-            li.appendChild(document.createTextNode(parameters[p].trim().toString()));
+            li.appendChild(document.createTextNode(parameters[p].toString().trim()));
         }
         ul.appendChild(li);
     }


### PR DESCRIPTION
When `parameters[p]` is a primitive data types, it doesn't have `trim()` defined and it causes exception to call. To avoid that, convert the value to `String` first and then invokes `trim()`.