### PR TITLE
[ros.showCoreStatus] Dispose the polling callbacks when webview closes.

### DIFF
--- a/src/ros/core-helper.ts
+++ b/src/ros/core-helper.ts
@@ -59,7 +59,7 @@ export function launchMonitor(context: vscode.ExtensionContext) {
 
     panel.webview.html = getCoreStatusWebviewContent(stylesheet, script);
 
-    setInterval(() => {
+    const pollingStatus = setInterval(() => {
         const masterApi = new XmlRpcApi(extension.env.ROS_MASTER_URI);
         masterApi.check().then((status: boolean) => {
             if (status) {
@@ -84,6 +84,9 @@ export function launchMonitor(context: vscode.ExtensionContext) {
             }
         });
     }, 100);
+    panel.onDidDispose(() => {
+        clearInterval(pollingStatus);
+    });
 }
 
 function getCoreStatusWebviewContent(stylesheet: vscode.Uri, script: vscode.Uri): string {


### PR DESCRIPTION
How to reproduce:
1. Run the `vscode-ros` in development mode.
2. Run `ros.startCore`
3. Run `ros.showCoreStatus`
4. Close core webview panel.

Expected behavior:
No exceptions are thrown from the debug console.

Actual behavior:
`rejected promise not handled within 1 second: Error: Webview is disposed` is keeping show up in debug console.