### PR TITLE
[ros2] add support for `ros2 launch`

### DIFF
--- a/src/ros/build-env-utils.ts
+++ b/src/ros/build-env-utils.ts
@@ -50,14 +50,14 @@ async function updateCppPropertiesInternal(): Promise<void> {
     let includes = await rosApi.getIncludeDirs();
 
     // Get all packages within the workspace that have an include directory
-    const filteredPackages = await rosApi.getPackages().then((packages: { [name: string]: string }) => {
-        return Object.values(packages).filter((packagePath: string) => {
-            return packagePath.startsWith(extension.baseDir);
+    const filteredPackages = await rosApi.getPackages().then((packages: { [name: string]: () => string }) => {
+        return Object.values(packages).filter((packagePath: () => string) => {
+            return packagePath().startsWith(extension.baseDir);
         });
     });
 
     await Promise.all(filteredPackages.map(pkg => {
-        const include = path.join(pkg, "include");
+        const include = path.join(pkg(), "include");
 
         return pfs.exists(include).then(exists => {
             if (exists) {

--- a/src/ros/build-env-utils.ts
+++ b/src/ros/build-env-utils.ts
@@ -50,8 +50,8 @@ async function updateCppPropertiesInternal(): Promise<void> {
     let includes = await rosApi.getIncludeDirs();
 
     // Get all packages within the workspace that have an include directory
-    const filteredPackages = await rosApi.getPackages().then((packages: { [name: string]: () => string }) => {
-        return Object.values(packages).filter(async (packagePath: () => string) => {
+    const filteredPackages = await rosApi.getPackages().then((packages: { [name: string]: () => Promise<string> }) => {
+        return Object.values(packages).filter(async (packagePath: () => Promise<string>) => {
             const packageBasePath = await packagePath();
             return packageBasePath.startsWith(extension.baseDir);
         });

--- a/src/ros/build-env-utils.ts
+++ b/src/ros/build-env-utils.ts
@@ -51,13 +51,15 @@ async function updateCppPropertiesInternal(): Promise<void> {
 
     // Get all packages within the workspace that have an include directory
     const filteredPackages = await rosApi.getPackages().then((packages: { [name: string]: () => string }) => {
-        return Object.values(packages).filter((packagePath: () => string) => {
-            return packagePath().startsWith(extension.baseDir);
+        return Object.values(packages).filter(async (packagePath: () => string) => {
+            const packageBasePath = await packagePath();
+            return packageBasePath.startsWith(extension.baseDir);
         });
     });
 
-    await Promise.all(filteredPackages.map(pkg => {
-        const include = path.join(pkg(), "include");
+    await Promise.all(filteredPackages.map(async pkg => {
+        const packageBasePath = await pkg();
+        const include = path.join(packageBasePath, "include");
 
         return pfs.exists(include).then(exists => {
             if (exists) {

--- a/src/ros/common/unknown-ros.ts
+++ b/src/ros/common/unknown-ros.ts
@@ -17,7 +17,7 @@ export class UnknownROS implements ros.ROSApi {
         return;
     }
 
-    public getPackages(): Promise<{ [name: string]: () => string }> {
+    public getPackages(): Promise<{ [name: string]: () => Promise<string> }> {
         console.error("Unknown ROS distro.");
         return;
     }

--- a/src/ros/common/unknown-ros.ts
+++ b/src/ros/common/unknown-ros.ts
@@ -17,7 +17,7 @@ export class UnknownROS implements ros.ROSApi {
         return;
     }
 
-    public getPackages(): Promise<{ [name: string]: string }> {
+    public getPackages(): Promise<{ [name: string]: () => string }> {
         console.error("Unknown ROS distro.");
         return;
     }

--- a/src/ros/ros.ts
+++ b/src/ros/ros.ts
@@ -21,7 +21,7 @@ export interface ROSApi {
     /**
      * Gets a map of package names to paths.
      */
-    getPackages: () => Promise<{ [name: string]: string }>;
+    getPackages: () => Promise<{ [name: string]: () => string }>;
 
     /**
      * Gets a list of CMake include paths.

--- a/src/ros/ros.ts
+++ b/src/ros/ros.ts
@@ -21,7 +21,7 @@ export interface ROSApi {
     /**
      * Gets a map of package names to paths.
      */
-    getPackages: () => Promise<{ [name: string]: () => string }>;
+    getPackages: () => Promise<{ [name: string]: () => Promise<string> }>;
 
     /**
      * Gets a list of CMake include paths.

--- a/src/ros/ros1/ros1.ts
+++ b/src/ros/ros1/ros1.ts
@@ -21,12 +21,12 @@ export class ROS1 implements ros.ROSApi {
     }
 
     public getPackageNames(): Promise<string[]> {
-        return this.getPackages().then((packages: { [name: string]: () => string }) => {
+        return this.getPackages().then((packages: { [name: string]: () => Promise<string> }) => {
             return Object.keys(packages);
         });
     }
 
-    public getPackages(): Promise<{ [name: string]: () => string }> {
+    public getPackages(): Promise<{ [name: string]: () => Promise<string> }> {
         return new Promise((resolve, reject) => child_process.exec("rospack list", { env: this._env }, (err, out) => {
             if (!err) {
                 const lines = out.trim().split(os.EOL).map(((line) => {

--- a/src/ros/ros1/ros1.ts
+++ b/src/ros/ros1/ros1.ts
@@ -11,13 +11,13 @@ import * as ros from "../ros";
 import * as ros_core from "./core-helper";
 
 export class ROS1 implements ros.ROSApi {
-    private _context: vscode.ExtensionContext;
-    private _env: any;
-    private _xmlRpcApi: ros_core.XmlRpcApi = null;
+    private context: vscode.ExtensionContext;
+    private env: any;
+    private xmlRpcApi: ros_core.XmlRpcApi = null;
 
     public setContext(context: vscode.ExtensionContext, env: any) {
-        this._context = context;
-        this._env = env;
+        this.context = context;
+        this.env = env;
     }
 
     public getPackageNames(): Promise<string[]> {
@@ -27,7 +27,7 @@ export class ROS1 implements ros.ROSApi {
     }
 
     public getPackages(): Promise<{ [name: string]: () => Promise<string> }> {
-        return new Promise((resolve, reject) => child_process.exec("rospack list", { env: this._env }, (err, out) => {
+        return new Promise((resolve, reject) => child_process.exec("rospack list", { env: this.env }, (err, out) => {
             if (!err) {
                 const lines = out.trim().split(os.EOL).map(((line) => {
                     const info: string[] = line.split(" ");
@@ -36,12 +36,12 @@ export class ROS1 implements ros.ROSApi {
                         return info;
                     }
                 }));
-    
+
                 const packageInfoReducer = (acc: object, cur: string[]) => {
                     const k: string = cur[0] as string;
                     const v: string = cur[1] as string;
                     acc[k] = async () => {
-                        return `${v}`;
+                        return v;
                     };
                     return acc;
                 };
@@ -54,8 +54,8 @@ export class ROS1 implements ros.ROSApi {
 
     public getIncludeDirs(): Promise<string[]> {
         const cmakePrefixPaths: string[] = [];
-        if (this._env.hasOwnProperty("CMAKE_PREFIX_PATH")) {
-            cmakePrefixPaths.push(...this._env.CMAKE_PREFIX_PATH.split(path.delimiter));
+        if (this.env.hasOwnProperty("CMAKE_PREFIX_PATH")) {
+            cmakePrefixPaths.push(...this.env.CMAKE_PREFIX_PATH.split(path.delimiter));
         }
 
         const includeDirs: string[] = [];
@@ -81,8 +81,8 @@ export class ROS1 implements ros.ROSApi {
         } else {
             const dirs = `catkin_find --without-underlays --libexec --share '${packageName}'`;
             command = `find $(${dirs}) -type f -executable`;
-            return new Promise((c, e) => child_process.exec(command, { env: this._env }, (err, out) =>
-                err ? e(err) : c(out.trim().split(os.EOL))
+            return new Promise((c, e) => child_process.exec(command, { env: this.env }, (err, out) =>
+                err ? e(err) : c(out.trim().split(os.EOL)),
             ));
         }
     }
@@ -91,34 +91,33 @@ export class ROS1 implements ros.ROSApi {
         let command: string;
         if (process.platform === "win32") {
             return this._findPackageFiles(packageName, `--share`, `*.launch`);
-        }
-        else {
+        } else {
             const dirs = `catkin_find --without-underlays --share '${packageName}'`;
             command = `find $(${dirs}) -type f -name *.launch`;
         }
 
-        return new Promise((c, e) => child_process.exec(command, { env: this._env }, (err, out) => {
+        return new Promise((c, e) => child_process.exec(command, { env: this.env }, (err, out) => {
             err ? e(err) : c(out.trim().split(os.EOL));
         }));
     }
 
     public startCore() {
-        if (typeof this._env.ROS_MASTER_URI === "undefined") {
-            return; 
+        if (typeof this.env.ROS_MASTER_URI === "undefined") {
+            return;
         }
-        ros_core.startCore(this._context);
+        ros_core.startCore(this.context);
     }
 
     public stopCore() {
-        if (typeof this._env.ROS_MASTER_URI === "undefined") {
-            return; 
+        if (typeof this.env.ROS_MASTER_URI === "undefined") {
+            return;
         }
-        ros_core.stopCore(this._context, this._getXmlRpcApi());
+        ros_core.stopCore(this.context, this._getXmlRpcApi());
     }
 
     public activateCoreMonitor(): vscode.Disposable {
-        if (typeof this._env.ROS_MASTER_URI === "undefined") {
-            return null; 
+        if (typeof this.env.ROS_MASTER_URI === "undefined") {
+            return null;
         }
         const coreStatusItem = new ros_core.StatusBarItem(this._getXmlRpcApi());
         coreStatusItem.activate();
@@ -126,12 +125,12 @@ export class ROS1 implements ros.ROSApi {
     }
 
     public showCoreMonitor() {
-        ros_core.launchMonitor(this._context);
+        ros_core.launchMonitor(this.context);
     }
 
-    public activateRosrun(packageName: string, executableName:string, argument: string): vscode.Terminal {
-        let terminal = vscode.window.createTerminal({
-            env: this._env,
+    public activateRosrun(packageName: string, executableName: string, argument: string): vscode.Terminal {
+        const terminal = vscode.window.createTerminal({
+            env: this.env,
             name: "rosrun",
         });
         terminal.sendText(`rosrun ${packageName} ${executableName} ${argument}`);
@@ -139,8 +138,8 @@ export class ROS1 implements ros.ROSApi {
     }
 
     public activateRoslaunch(launchFilepath: string, argument: string): vscode.Terminal {
-        let terminal = vscode.window.createTerminal({
-            env: this._env,
+        const terminal = vscode.window.createTerminal({
+            env: this.env,
             name: "roslaunch",
         });
         terminal.sendText(`roslaunch ${launchFilepath} ${argument}`);
@@ -148,34 +147,34 @@ export class ROS1 implements ros.ROSApi {
     }
 
     private _findPackageFiles(packageName: string, filter: string, pattern: string): Promise<string[]> {
-        return new Promise((c, _e) => child_process.exec(`catkin_find --without-underlays ${filter} ${packageName}`,
-            { env: this._env }, (_err, out) => {
-                let findFilePromises = [];
-                let paths = out.trim().split(os.EOL);
-                paths.forEach(foundPath => {
-                    let normalizedPath = path.win32.normalize(foundPath);
-                    findFilePromises.push(new Promise((found) => child_process.exec(`where /r "${normalizedPath}" ` + pattern,
-                        { env: this._env }, (err, out) =>
-                            err ? found(null) : found(out.trim().split(os.EOL))
+        return new Promise((c, e) => child_process.exec(`catkin_find --without-underlays ${filter} ${packageName}`,
+            { env: this.env }, (err, out) => {
+                const findFilePromises = [];
+                const paths = out.trim().split(os.EOL);
+                paths.forEach((foundPath) => {
+                    const normalizedPath = path.win32.normalize(foundPath);
+                    findFilePromises.push(new Promise((found) => child_process.exec(
+                        `where /r "${normalizedPath}" ` + pattern, { env: this.env }, (innerErr, innerOut) =>
+                            innerErr ? found(null) : found(innerOut.trim().split(os.EOL)),
                     )));
                 });
 
-                return Promise.all(findFilePromises).then(values => {
+                return Promise.all(findFilePromises).then((values) => {
                     // remove null elements
-                    values = values.filter(s => s != null) as string[];
+                    values = values.filter((s) => s != null) as string[];
 
                     // flatten
                     values = [].concat(...values);
                     c(values);
                 });
-            }
+            },
         ));
     }
 
     private _getXmlRpcApi(): ros_core.XmlRpcApi {
-        if (this._xmlRpcApi === null) {
-            this._xmlRpcApi = new ros_core.XmlRpcApi(this._env.ROS_MASTER_URI);
+        if (this.xmlRpcApi === null) {
+            this.xmlRpcApi = new ros_core.XmlRpcApi(this.env.ROS_MASTER_URI);
         }
-        return this._xmlRpcApi;
+        return this.xmlRpcApi;
     }
 }

--- a/src/ros/ros1/ros1.ts
+++ b/src/ros/ros1/ros1.ts
@@ -21,12 +21,12 @@ export class ROS1 implements ros.ROSApi {
     }
 
     public getPackageNames(): Promise<string[]> {
-        return this.getPackages().then((packages: { [name: string]: string }) => {
+        return this.getPackages().then((packages: { [name: string]: () => string }) => {
             return Object.keys(packages);
         });
     }
 
-    public getPackages(): Promise<{ [name: string]: string }> {
+    public getPackages(): Promise<{ [name: string]: () => string }> {
         return new Promise((resolve, reject) => child_process.exec("rospack list", { env: this._env }, (err, out) => {
             if (!err) {
                 const lines = out.trim().split(os.EOL).map(((line) => {
@@ -40,7 +40,9 @@ export class ROS1 implements ros.ROSApi {
                 const packageInfoReducer = (acc: object, cur: string[]) => {
                     const k: string = cur[0] as string;
                     const v: string = cur[1] as string;
-                    acc[k] = v;
+                    acc[k] = async () => {
+                        return `${v}`;
+                    };
                     return acc;
                 };
                 resolve(lines.reduce(packageInfoReducer, {}));

--- a/src/ros/ros2/ros2.ts
+++ b/src/ros/ros2/ros2.ts
@@ -29,29 +29,20 @@ export class ROS2 implements ros.ROSApi {
         }));
     }
 
-    public getPackages(): Promise<{ [name: string]: () => string }> {
-        return new Promise((resolve, reject) => child_process.exec("ros2 pkg list", { env: this._env }, (err, out) => {
-            if (!err) {
-                const lines = out.trim().split(os.EOL).map(((line) => {
-                    return line;
-                }));
-
-                const packageInfoReducer = (acc: object, cur: string) => {
-                    const k: string = cur;
-                    acc[k] = async () => {
-                        const { stdout } = await child_process.exec(`ros2 pkg prefix --share ${k}`, { env: this._env });
-                        for await (const line of stdout) {
-                            return line.trim();
-                        }
-                        return "";
-                    };
-                    return acc;
-                };
-                resolve(lines.reduce(packageInfoReducer, {}));
-            } else {
-                reject(err);
-            }
-        }));
+    public async getPackages(): Promise<{ [name: string]: () => Promise<string> }> {
+        let packages: { [name: string]: () => Promise<string> } = {};
+        const {stdout} = child_process.exec("ros2 pkg list", { env: this._env });
+        for await (const line of stdout) {
+            const packageName:string = line.trim();
+            packages[packageName] = async (): Promise<string> => {
+                const { stdout } = await child_process.exec(`ros2 pkg prefix --share ${packageName}`, { env: this._env });
+                for await (const line of stdout) {
+                    return line.trim();
+                }
+                return "";
+            };
+        }
+        return packages;
     }
 
     public getIncludeDirs(): Promise<string[]> {

--- a/src/ros/ros2/ros2.ts
+++ b/src/ros/ros2/ros2.ts
@@ -8,16 +8,16 @@ import * as vscode from "vscode";
 import * as ros from "../ros";
 
 export class ROS2 implements ros.ROSApi {
-    private _context: vscode.ExtensionContext;
-    private _env: any;
+    private context: vscode.ExtensionContext;
+    private env: any;
 
     public setContext(context: vscode.ExtensionContext, env: any) {
-        this._context = context;
-        this._env = env;
+        this.context = context;
+        this.env = env;
     }
 
     public getPackageNames(): Promise<string[]> {
-        return new Promise((resolve, reject) => child_process.exec("ros2 pkg list", { env: this._env }, (err, out) => {
+        return new Promise((resolve, reject) => child_process.exec("ros2 pkg list", { env: this.env }, (err, out) => {
             if (!err) {
                 const lines = out.trim().split(os.EOL).map(((line) => {
                     return line;
@@ -30,22 +30,23 @@ export class ROS2 implements ros.ROSApi {
     }
 
     public async getPackages(): Promise<{ [name: string]: () => Promise<string> }> {
-        let packages: { [name: string]: () => Promise<string> } = {};
-        const {stdout} = child_process.exec("ros2 pkg list", { env: this._env });
+        const packages: { [name: string]: () => Promise<string> } = {};
+        const { stdout } = child_process.exec("ros2 pkg list", { env: this.env });
         let chucks = "";
         for await (const chuck of stdout) {
             chucks += chuck;
         }
 
         chucks.split(os.EOL).map(((line) => {
-            const packageName:string = line.trim();
+            const packageName: string = line.trim();
             packages[packageName] = async (): Promise<string> => {
-                const { stdout } = await child_process.exec(`ros2 pkg prefix --share ${packageName}`, { env: this._env });
-                let chucks = "";
+                const { stdout } = await child_process.exec(
+                    `ros2 pkg prefix --share ${packageName}`, { env: this.env });
+                let innerChucks = "";
                 for await (const chuck of stdout) {
-                    chucks += chuck;
+                    innerChucks += chuck;
                 }
-                return chucks.trim();
+                return innerChucks.trim();
             };
         }));
 
@@ -59,7 +60,8 @@ export class ROS2 implements ros.ROSApi {
     }
 
     public findPackageExecutables(packageName: string): Promise<string[]> {
-        return new Promise((resolve, reject) => child_process.exec(`ros2 pkg executables ${packageName}`, { env: this._env }, (err, out) => {
+        return new Promise((resolve, reject) => child_process.exec(
+            `ros2 pkg executables ${packageName}`, { env: this.env }, (err, out) => {
             if (!err) {
                 const lines = out.trim().split(os.EOL).map(((line) => {
                     const info: string[] = line.split(" ");
@@ -68,7 +70,7 @@ export class ROS2 implements ros.ROSApi {
                         return info;
                     }
                 }));
-    
+
                 const packageInfoReducer = (acc: string[], cur: string[]) => {
                     const executableName: string = cur[1] as string;
                     acc.push(executableName);
@@ -82,17 +84,13 @@ export class ROS2 implements ros.ROSApi {
     }
 
     public async findPackageLaunchFiles(packageName: string): Promise<string[]> {
-        let packages = await this.getPackages();
-        let packageBasePath = await packages[packageName]();
-        let command:string;
-        if (process.platform === "win32") {
-            command = `where /r "${packageBasePath}" *.launch.py`;
-        }
-        else {
-            command = `find $(${packageBasePath}) -type f -name *.launch.py`;
-        }
+        const packages = await this.getPackages();
+        const packageBasePath = await packages[packageName]();
+        const command: string = (process.platform === "win32") ?
+            `where /r "${packageBasePath}" *.launch.py` :
+            `find $(${packageBasePath}) -type f -name *.launch.py`;
 
-        return new Promise((c, e) => child_process.exec(command, { env: this._env }, (err, out) => {
+        return new Promise((c, e) => child_process.exec(command, { env: this.env }, (err, out) => {
             err ? e(err) : c(out.trim().split(os.EOL));
         }));
     }
@@ -117,9 +115,9 @@ export class ROS2 implements ros.ROSApi {
         return;
     }
 
-    public activateRosrun(packageName: string, executableName:string, argument: string): vscode.Terminal {
-        let terminal = vscode.window.createTerminal({
-            env: this._env,
+    public activateRosrun(packageName: string, executableName: string, argument: string): vscode.Terminal {
+        const terminal = vscode.window.createTerminal({
+            env: this.env,
             name: "ros2 run",
         });
         terminal.sendText(`ros2 run ${packageName} ${executableName} ${argument}`);
@@ -127,8 +125,8 @@ export class ROS2 implements ros.ROSApi {
     }
 
     public activateRoslaunch(launchFilepath: string, argument: string): vscode.Terminal {
-        let terminal = vscode.window.createTerminal({
-            env: this._env,
+        const terminal = vscode.window.createTerminal({
+            env: this.env,
             name: "ros2 launch",
         });
         terminal.sendText(`ros2 launch ${launchFilepath} ${argument}`);

--- a/src/ros/ros2/ros2.ts
+++ b/src/ros/ros2/ros2.ts
@@ -29,10 +29,29 @@ export class ROS2 implements ros.ROSApi {
         }));
     }
 
-    public getPackages(): Promise<{ [name: string]: string }> {
-        return new Promise((resolve, reject) => {
-            reject("not yet implemented");
-        });
+    public getPackages(): Promise<{ [name: string]: () => string }> {
+        return new Promise((resolve, reject) => child_process.exec("ros2 pkg list", { env: this._env }, (err, out) => {
+            if (!err) {
+                const lines = out.trim().split(os.EOL).map(((line) => {
+                    return line;
+                }));
+
+                const packageInfoReducer = (acc: object, cur: string) => {
+                    const k: string = cur;
+                    acc[k] = async () => {
+                        const { stdout } = await child_process.exec(`ros2 pkg prefix --share ${k}`, { env: this._env });
+                        for await (const line of stdout) {
+                            return line.trim();
+                        }
+                        return "";
+                    };
+                    return acc;
+                };
+                resolve(lines.reduce(packageInfoReducer, {}));
+            } else {
+                reject(err);
+            }
+        }));
     }
 
     public getIncludeDirs(): Promise<string[]> {
@@ -64,10 +83,20 @@ export class ROS2 implements ros.ROSApi {
         }));
     }
 
-    public findPackageLaunchFiles(packageName: string): Promise<string[]> {
-        return new Promise((resolve, reject) => {
-            reject("not yet implemented");
-        });
+    public async findPackageLaunchFiles(packageName: string): Promise<string[]> {
+        let packages = await this.getPackages();
+        let packageBasePath = await packages[packageName]();
+        let command:string;
+        if (process.platform === "win32") {
+            command = `where /r "${packageBasePath}" *.launch.py`;
+        }
+        else {
+            command = `find $(${packageBasePath}) -type f -name *.launch.py`;
+        }
+
+        return new Promise((c, e) => child_process.exec(command, { env: this._env }, (err, out) => {
+            err ? e(err) : c(out.trim().split(os.EOL));
+        }));
     }
 
     public startCore() {
@@ -100,7 +129,11 @@ export class ROS2 implements ros.ROSApi {
     }
 
     public activateRoslaunch(launchFilepath: string, argument: string): vscode.Terminal {
-        // not yet implemented.
-        return null;
+        let terminal = vscode.window.createTerminal({
+            env: this._env,
+            name: "ros2 launch",
+        });
+        terminal.sendText(`ros2 launch ${launchFilepath} ${argument}`);
+        return terminal;
     }
 }

--- a/src/ros/ros2/ros2.ts
+++ b/src/ros/ros2/ros2.ts
@@ -32,16 +32,23 @@ export class ROS2 implements ros.ROSApi {
     public async getPackages(): Promise<{ [name: string]: () => Promise<string> }> {
         let packages: { [name: string]: () => Promise<string> } = {};
         const {stdout} = child_process.exec("ros2 pkg list", { env: this._env });
-        for await (const line of stdout) {
+        let chucks = "";
+        for await (const chuck of stdout) {
+            chucks += chuck;
+        }
+
+        chucks.split(os.EOL).map(((line) => {
             const packageName:string = line.trim();
             packages[packageName] = async (): Promise<string> => {
                 const { stdout } = await child_process.exec(`ros2 pkg prefix --share ${packageName}`, { env: this._env });
-                for await (const line of stdout) {
-                    return line.trim();
+                let chucks = "";
+                for await (const chuck of stdout) {
+                    chucks += chuck;
                 }
-                return "";
+                return chucks.trim();
             };
-        }
+        }));
+
         return packages;
     }
 

--- a/src/urdfPreview/preview.ts
+++ b/src/urdfPreview/preview.ts
@@ -116,7 +116,7 @@ export default class URDFPreview
         var pattern =  /package:\/\/(.*?)\//g;
         var match;
         while (match = pattern.exec(urdfText)) {
-            var packagePath = packageMap[match[1]];
+            var packagePath = await packageMap[match[1]]();
             if (packagePath.charAt(0)  === '/') {
                 // inside of mesh re \source, the loader attempts to concatinate the base uri with the new path. It first checks to see if the
                 // base path has a /, if not it adds it.


### PR DESCRIPTION
* Implemented `getPackages()`. `findPackageLaunchFiles()`, and `activateRoslaunch()` for ROS2, which are required to enable `ros.roslaunch` extension command.