### PR TITLE
[ros2] ros2 system status monitor

### DIFF
--- a/src/ros/ros2/daemon.ts
+++ b/src/ros/ros2/daemon.ts
@@ -56,6 +56,8 @@ export class StatusBarItem {
         try {
             const result = await this.ros2cli.getNodeNamesAndNamespaces();
             status = true;
+        } catch (error) {
+            // do nothing.
         } finally {
             this.item.text = (status ? "$(check)" : "$(x)") + " ROS2 Daemon";
             this.timeout = setTimeout(() => this.update(), 200);

--- a/src/ros/ros2/daemon.ts
+++ b/src/ros/ros2/daemon.ts
@@ -6,6 +6,7 @@ import * as util from "util";
 import * as vscode from "vscode";
 
 import * as extension from "../../extension";
+import * as ros2_monitor from "./ros2-monitor"
 
 /**
  * start the ROS2 daemon.
@@ -31,11 +32,13 @@ export async function stopDaemon() {
 export class StatusBarItem {
     private item: vscode.StatusBarItem;
     private timeout: NodeJS.Timeout;
+    private ros2cli: ros2_monitor.XmlRpcApi;
 
     public constructor() {
         this.item = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 200);
         this.item.text = "$(question) ROS2 Daemon";
         this.item.command = extension.Commands.ShowCoreStatus;
+        this.ros2cli = new ros2_monitor.XmlRpcApi();
     }
 
     public activate() {
@@ -49,12 +52,13 @@ export class StatusBarItem {
     }
 
     private async update() {
-        const command: string = "ros2 daemon status";
-        const exec = util.promisify(child_process.exec);
-        const { stdout } = await exec(command, { env: extension.env });
-        const status: boolean = stdout.includes("The daemon is running");
-        this.item.text = (status ? "$(check)" : "$(x)") + " ROS2 Daemon";
-        this.timeout = setTimeout(() => this.update(), 200);
-        return;
+        let status: boolean = false;
+        try {
+            const result = await this.ros2cli.getNodeNamesAndNamespaces();
+            status = true;
+        } finally {
+            this.item.text = (status ? "$(check)" : "$(x)") + " ROS2 Daemon";
+            this.timeout = setTimeout(() => this.update(), 200);
+        }
     }
 }

--- a/src/ros/ros2/ros2-monitor.ts
+++ b/src/ros/ros2/ros2-monitor.ts
@@ -1,4 +1,4 @@
-// Copyright (c) Andrew Short. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 import * as path from "path";

--- a/src/ros/ros2/ros2-monitor.ts
+++ b/src/ros/ros2/ros2-monitor.ts
@@ -80,7 +80,7 @@ function getCoreStatusWebviewContent(stylesheet: vscode.Uri, script: vscode.Uri)
 </head>
 
 <body>
-    <h1>ROS Core Status</h1>
+    <h1>ROS2 System Status</h1>
     <h2 id="ros-status">-</h2>
 
     <div id="parameters"></div>

--- a/src/ros/ros2/ros2-monitor.ts
+++ b/src/ros/ros2/ros2-monitor.ts
@@ -1,0 +1,128 @@
+// Copyright (c) Andrew Short. All rights reserved.
+// Licensed under the MIT License.
+
+import * as path from "path";
+import * as vscode from "vscode";
+import * as xmlrpc from "xmlrpc";
+
+import * as extension from "../../extension";
+import * as telemetry from "../../telemetry-helper";
+
+function getDaemonPort() {
+    let basePort: number = 11511;
+    return basePort;
+}
+
+function getDaemonUri() {
+    return `http://localhost:${getDaemonPort()}/ros2cli/`;
+}
+
+export function launchMonitor(context: vscode.ExtensionContext) {
+    const reporter = telemetry.getReporter(context);
+    reporter.sendTelemetryCommand(extension.Commands.ShowCoreStatus);
+
+    const panel = vscode.window.createWebviewPanel(
+        "ros2Status",
+        "ROS2 Status",
+        vscode.ViewColumn.Two,
+        {
+            enableScripts: true,
+        }
+    );
+
+    const stylesheet = vscode.Uri.file(path.join(context.extensionPath, "assets", "ros", "core-monitor", "style.css")).with({
+        scheme: "vscode-resource"
+    });
+
+    const script = vscode.Uri.file(path.join(context.extensionPath, "out", "src", "ros", "ros2", "webview", "main.js")).with({
+        scheme: "vscode-resource"
+    });
+
+    panel.webview.html = getCoreStatusWebviewContent(stylesheet, script);
+
+    const ros2cliApi = new XmlRpcApi();
+    const pollingHandle = setInterval(async () => {
+        try {
+            const result: any[] = await Promise.all([
+                ros2cliApi.getNodeNamesAndNamespaces(), 
+                ros2cliApi.getTopicNamesAndTypes(), 
+                ros2cliApi.getServiceNamesAndTypes()]);
+            const nodesJSON = JSON.stringify(result[0]);
+            const topicsJSON = JSON.stringify(result[1]);
+            const servicesJSON = JSON.stringify(result[2]);
+            panel.webview.postMessage({
+                ready: true,
+                nodes: nodesJSON,
+                topics: topicsJSON,
+                services: servicesJSON,
+            });
+        } catch (e) {
+            panel.webview.postMessage({
+                ready: false,
+            });
+        }
+    }, 200);
+
+    panel.onDidDispose(() => {
+        clearInterval(pollingHandle);
+    });
+}
+
+function getCoreStatusWebviewContent(stylesheet: vscode.Uri, script: vscode.Uri): string {
+    return `
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <link rel="stylesheet" href="${stylesheet.toString()}" />
+
+    <script src="${script.toString()}"></script>
+</head>
+
+<body>
+    <h1>ROS Core Status</h1>
+    <h2 id="ros-status">-</h2>
+
+    <div id="parameters"></div>
+    <div id="topics"></div>
+    <div id="services"></div>
+</body>
+
+</html>
+`;
+}
+
+/**
+ * ros2cli xmlrpc interfaces.
+ */
+export class XmlRpcApi {
+    private client: xmlrpc.Client;
+
+    public constructor() {
+        this.client = xmlrpc.createClient(getDaemonUri());
+    }
+
+    public getNodeNamesAndNamespaces() : Promise<any> {
+        return this.methodCall("get_node_names_and_namespaces");
+    }
+
+    public getServiceNamesAndTypes() : Promise<any> {
+        return this.methodCall("get_service_names_and_types");
+    }
+
+    public getTopicNamesAndTypes() : Promise<any> {
+        return this.methodCall("get_topic_names_and_types");
+    }
+
+    private methodCall(method: string, ...args: any[]): Promise<any> {
+        return new Promise((resolve, reject) => {
+            this.client.methodCall(method, [...args], (err, val) => {
+                if (err) {
+                    reject(err);
+                } else {
+                    resolve(val);
+                }
+            });
+        });
+    }
+}

--- a/src/ros/ros2/ros2.ts
+++ b/src/ros/ros2/ros2.ts
@@ -7,6 +7,7 @@ import * as vscode from "vscode";
 
 import * as ros from "../ros";
 import * as daemon from "./daemon";
+import * as ros2_monitor from "./ros2-monitor";
 
 export class ROS2 implements ros.ROSApi {
     private context: vscode.ExtensionContext;
@@ -110,9 +111,8 @@ export class ROS2 implements ros.ROSApi {
         return coreStatusItem;
     }
 
-    public showCoreMonitor() {
-        // not yet implemented.
-        return;
+    public async showCoreMonitor() {
+        return ros2_monitor.launchMonitor(this.context);
     }
 
     public activateRosrun(packageName: string, executableName: string, argument: string): vscode.Terminal {

--- a/src/ros/ros2/webview/main.ts
+++ b/src/ros/ros2/webview/main.ts
@@ -8,14 +8,10 @@ namespace ros2monitor {
         }
     };
 
-    function generateNamesAndTypesTable(tuples) {
+    function generateColumnTable(dataArray: any, headers: string[], callback: (data: any, i: number) => string) {
         let t = document.createElement("table");
         let th = document.createElement("thead");
         let headerRow = document.createElement("tr");
-        let headers = [
-            "Name",
-            "Type"
-        ];
         headers.forEach((name, _i) => {
             let h = document.createElement("th");
             h.appendChild(document.createTextNode(name));
@@ -26,17 +22,14 @@ namespace ros2monitor {
         t.appendChild(th);
 
         let tb = document.createElement("tbody");
-        for (let i in tuples) {
-            let tuple = tuples[i];
-            let r = document.createElement("tr");
-            let name = document.createElement("td");
-            name.appendChild(document.createTextNode(tuple[0]));
-
-            let type = document.createElement("td");
-            type.appendChild(document.createTextNode(tuple[1]));
-
-            r.appendChild(name);
-            r.appendChild(type);
+        for (const i in dataArray) {
+            const data = dataArray[i];
+            const r = document.createElement("tr");
+            headers.forEach((name, _i) => {
+                let cell = document.createElement("td");
+                cell.appendChild(document.createTextNode(callback(data, _i)));
+                r.appendChild(cell);
+            });
             tb.appendChild(r);
         }
         t.appendChild(tb);
@@ -59,19 +52,30 @@ namespace ros2monitor {
             if (message.ready) {
                 coreStatus.textContent = "online";
 
-                //const nodes = JSON.parse(message.nodes);
+                const nodes = JSON.parse(message.nodes);
                 const topics = JSON.parse(message.topics);
                 const services = JSON.parse(message.services);
+
+                const nodesHeader = document.createElement("h2");
+                nodesHeader.appendChild(document.createTextNode("Nodes"));
+                topicsElement.appendChild(nodesHeader);
+                topicsElement.appendChild(generateColumnTable(nodes, ["Name"], (data, i) => {
+                    return `${data[1]}${data[0]}`;
+                }));
 
                 const topicsHeader = document.createElement("h2");
                 topicsHeader.appendChild(document.createTextNode("Topics"));
                 topicsElement.appendChild(topicsHeader);
-                topicsElement.appendChild(generateNamesAndTypesTable(topics));
+                topicsElement.appendChild(generateColumnTable(topics, ["Name", "Type"], (data, i) => {
+                    return data[i];
+                }));
 
                 const servicesHeader = document.createElement("h2");
                 servicesHeader.appendChild(document.createTextNode("Services"));
                 servicesElement.appendChild(servicesHeader);
-                servicesElement.appendChild(generateNamesAndTypesTable(services));
+                servicesElement.appendChild(generateColumnTable(services, ["Name", "Type"], (data, i) => {
+                    return data[i];
+                }));
             }
             else {
                 coreStatus.textContent = "offline";

--- a/src/ros/ros2/webview/main.ts
+++ b/src/ros/ros2/webview/main.ts
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace ros2monitor {
+    function removeAllChildElements(e) {
+        while (e.firstChild) {
+            e.removeChild(e.firstChild);
+        }
+    };
+
+    function generateNamesAndTypesTable(tuples) {
+        let t = document.createElement("table");
+        let th = document.createElement("thead");
+        let headerRow = document.createElement("tr");
+        let headers = [
+            "Name",
+            "Type"
+        ];
+        headers.forEach((name, _i) => {
+            let h = document.createElement("th");
+            h.appendChild(document.createTextNode(name));
+            headerRow.appendChild(h);
+        });
+
+        th.appendChild(headerRow);
+        t.appendChild(th);
+
+        let tb = document.createElement("tbody");
+        for (let i in tuples) {
+            let tuple = tuples[i];
+            let r = document.createElement("tr");
+            let name = document.createElement("td");
+            name.appendChild(document.createTextNode(tuple[0]));
+
+            let type = document.createElement("td");
+            type.appendChild(document.createTextNode(tuple[1]));
+
+            r.appendChild(name);
+            r.appendChild(type);
+            tb.appendChild(r);
+        }
+        t.appendChild(tb);
+
+        return t;
+    }
+
+    export function initializeRos2Monitor() {
+        // handle message passed from extension to webview
+        window.addEventListener("message", (event) => {
+            const message = event.data;
+
+            const coreStatus = document.getElementById("ros-status");
+            const topicsElement = document.getElementById("topics");
+            const servicesElement = document.getElementById("services");
+
+            removeAllChildElements(topicsElement);
+            removeAllChildElements(servicesElement);
+
+            if (message.ready) {
+                coreStatus.textContent = "online";
+
+                //const nodes = JSON.parse(message.nodes);
+                const topics = JSON.parse(message.topics);
+                const services = JSON.parse(message.services);
+
+                const topicsHeader = document.createElement("h2");
+                topicsHeader.appendChild(document.createTextNode("Topics"));
+                topicsElement.appendChild(topicsHeader);
+                topicsElement.appendChild(generateNamesAndTypesTable(topics));
+
+                const servicesHeader = document.createElement("h2");
+                servicesHeader.appendChild(document.createTextNode("Services"));
+                servicesElement.appendChild(servicesHeader);
+                servicesElement.appendChild(generateNamesAndTypesTable(services));
+            }
+            else {
+                coreStatus.textContent = "offline";
+            }
+        });
+    };
+}
+
+window.onload = () => ros2monitor.initializeRos2Monitor();


### PR DESCRIPTION
* `ROS2 System Status Webview`: use `xmlrpc` client to mimic [`ros2cli`](https://github.com/ros2/ros2cli/blob/master/ros2cli/ros2cli/daemon/__init__.py) behavior and query the available ROS2 system status. 
* `ROS2 StatusBarItem`:  replace `ros2 daemon status` CLI call with `xmlrpc` method call to query the system readiness, which reduces the overall CPU usage.