### PR TITLE
use Node.js >=10.2.0

### DIFF
--- a/ci/azure-pipelines.release.yml
+++ b/ci/azure-pipelines.release.yml
@@ -15,7 +15,8 @@ pr:
     - release/*
 
 variables:
-  nodeVersion: '>=10.15.3'
+  # VS Code extensions run on Node.js >=10.2.0 since January 2019 (version 1.31) release
+  nodeVersion: '>=10.2.0'
   npmVersion: 'latest'
 
 stages:

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -31,7 +31,8 @@ pr:
     - release/*
 
 variables:
-  nodeVersion: '>=10.15.3'
+  # VS Code extensions run on Node.js >=10.2.0 since January 2019 (version 1.31) release
+  nodeVersion: '>=10.2.0'
   npmVersion: 'latest'
 
 stages:


### PR DESCRIPTION
VS Code uses Node.js `>=10.2.0` since https://code.visualstudio.com/updates/v1_31

the latest VS Code `1.37.1` runs `10.11.0`
![image](https://user-images.githubusercontent.com/44008378/63394198-739f8400-c373-11e9-85a8-de9d8f288410.png)

*however, this change does not actually affect pipeline since `>=10.x` will still resolve to the latest `10.x` version*