### PR TITLE
[ros2] Add ros2 support for ros.updateCppProperties

### DIFF
--- a/src/ros/common/unknown-ros.ts
+++ b/src/ros/common/unknown-ros.ts
@@ -27,6 +27,11 @@ export class UnknownROS implements ros.ROSApi {
         return;
     }
 
+    public getWorkspaceIncludeDirs(workspaceDir: string): Promise<string[]> {
+        console.error("Unknown ROS distro.");
+        return;
+    }
+
     public findPackageExecutables(packageName: string): Promise<string[]> {
         console.error("Unknown ROS distro.");
         return;

--- a/src/ros/ros.ts
+++ b/src/ros/ros.ts
@@ -29,6 +29,12 @@ export interface ROSApi {
     getIncludeDirs: () => Promise<string[]>;
 
     /**
+     * Gets a list of include paths under current workspace.
+     * @param workspaceDir
+     */
+    getWorkspaceIncludeDirs: (workspaceDir: string) => Promise<string[]>;
+
+    /**
      * list full paths to all executables inside a package
      * @param packageName 
      */


### PR DESCRIPTION
In this change, I abstracted out `getWorkspaceIncludeDirs` into `rosApi` since ROS1 and ROS2 is using different approaches to get the workspace include directories. And in ROS2, I used `colcon list -p` to get the base paths for packages under a workspace, and add those paths where a `include` subfolder exists.