### PR TITLE
enable launching C++ and Python binaries on Linux

### DIFF
--- a/src/debugger/configuration/resolvers/launch.ts
+++ b/src/debugger/configuration/resolvers/launch.ts
@@ -130,6 +130,14 @@ export class LaunchResolver implements vscode.DebugConfigurationProvider {
                 };
                 debugConfig = cppvsdbgLaunchConfig;
             }
+
+            if (!debugConfig) {
+                throw (new Error(`Failed to create a debug configuration!`));
+            }
+            const launched = await vscode.debug.startDebugging(undefined, debugConfig);
+            if (!launched) {
+                throw (new Error(`Failed to start debug session!`));
+            }
         } else {
             try {
                 // this should be guaranteed by roslaunch
@@ -155,10 +163,12 @@ export class LaunchResolver implements vscode.DebugConfigurationProvider {
             let linesToRead: number = 1;
             rl.on("line", async (line) => {
                 if (linesToRead <= 0) {
-                    rl.close();
                     return;
                 }
                 linesToRead--;
+                if (!linesToRead) {
+                    rl.close();
+                }
 
                 // look for Python in shebang line
                 if (line.startsWith("#!") && line.toLowerCase().indexOf("python") !== -1) {
@@ -198,15 +208,15 @@ export class LaunchResolver implements vscode.DebugConfigurationProvider {
                     };
                     debugConfig = cppdbgLaunchConfig;
                 }
-            });
-        }
 
-        if (!debugConfig) {
-            return;
-        }
-        const launched = await vscode.debug.startDebugging(undefined, debugConfig);
-        if (!launched) {
-            throw (new Error(`Failed to start debug session!`));
+                if (!debugConfig) {
+                    throw (new Error(`Failed to create a debug configuration!`));
+                }
+                const launched = await vscode.debug.startDebugging(undefined, debugConfig);
+                if (!launched) {
+                    throw (new Error(`Failed to start debug session!`));
+                }
+            });
         }
     }
 }


### PR DESCRIPTION
C++ binary and Python scripts are all executable on Linux, to distinguish between these 2, need to check shebang line for the Python script. In this change, we read the first line of the executable and check if it is a shebang pointing to Python, and launch Python/C++ debug sessions based on that check.

also in this change: pass down ROS node names to debug sessions for better readability