### PR TITLE
Correct task provider usages

### DIFF
--- a/package.json
+++ b/package.json
@@ -223,7 +223,7 @@
         },
         "problemMatchers": [
             {
-                "name": "$catkin-gcc",
+                "name": "catkin-gcc",
                 "fileLocation": "absolute",
                 "owner": "catkin",
                 "pattern": {
@@ -234,6 +234,20 @@
                     "severity": 4,
                     "message": 5
                 }
+            }
+        ],
+        "taskDefinitions": [
+            {
+                "type": "catkin_make"
+            },
+            {
+                "type": "catkin_make_isolated"
+            },
+            {
+                "type": "catkin"
+            },
+            {
+                "type": "colcon"
             }
         ]
     },

--- a/src/build-tool/build-tool.ts
+++ b/src/build-tool/build-tool.ts
@@ -13,7 +13,7 @@ import * as colcon from "./colcon";
 
 export abstract class BuildTool {
     public static current: BuildTool;
-    public static registerTaskProvider(): vscode.Disposable {
+    public static registerTaskProvider(): vscode.Disposable[] {
         return this.current._registerTaskProvider();
     }
 
@@ -23,13 +23,13 @@ export abstract class BuildTool {
         return this.current._createPackage();
     }
 
-    protected abstract _registerTaskProvider(): vscode.Disposable;
+    protected abstract _registerTaskProvider(): vscode.Disposable[];
     protected abstract async _createPackage(): Promise<void>;
 }
 
 // tslint:disable-next-line: max-classes-per-file
 class NotImplementedBuildTool extends BuildTool {
-    protected _registerTaskProvider(): vscode.Disposable {
+    protected _registerTaskProvider(): vscode.Disposable[] {
         return null;
     }
 
@@ -44,8 +44,11 @@ class CatkinCmakeBuildTool extends BuildTool {
         return pfs.exists(`${dir}/.catkin_workspace`);
     }
 
-    protected _registerTaskProvider(): vscode.Disposable {
-        return vscode.workspace.registerTaskProvider("catkin_cmake", new catkin.CatkinProvider());
+    protected _registerTaskProvider(): vscode.Disposable[] {
+        return [
+            vscode.tasks.registerTaskProvider("catkin_cmake", new catkin.CatkinMakeProvider()),
+            vscode.tasks.registerTaskProvider("catkin_cmake_isolated", new catkin.CatkinMakeIsolatedProvider()),
+        ];
     }
 
     protected async _createPackage(): Promise<void> {
@@ -59,8 +62,8 @@ class CatkinToolsBuildTool extends BuildTool {
         return pfs.exists(`${dir}/.catkin_tools`);
     }
 
-    protected _registerTaskProvider(): vscode.Disposable {
-        return vscode.workspace.registerTaskProvider("catkin_tools", new catkin_tools.CatkinToolsProvider());
+    protected _registerTaskProvider(): vscode.Disposable[] {
+        return [vscode.tasks.registerTaskProvider("catkin", new catkin_tools.CatkinToolsProvider())];
     }
 
     protected async _createPackage(): Promise<void> {
@@ -74,8 +77,8 @@ class ColconBuildTool extends BuildTool {
         return colcon.isApplicable(dir);
     }
 
-    protected _registerTaskProvider(): vscode.Disposable {
-        return vscode.workspace.registerTaskProvider("colcon", new colcon.ColconProvider());
+    protected _registerTaskProvider(): vscode.Disposable[] {
+        return [vscode.tasks.registerTaskProvider("colcon", new colcon.ColconProvider())];
     }
 
     protected async _createPackage(): Promise<void> {

--- a/src/build-tool/catkin-tools.ts
+++ b/src/build-tool/catkin-tools.ts
@@ -24,7 +24,7 @@ export class CatkinToolsProvider implements vscode.TaskProvider {
         make.group = vscode.TaskGroup.Build;
         make.problemMatchers = ["$catkin-gcc"];
 
-        const test = new vscode.Task({ type: "catkin", target: "run_tests" }, "run_tests", "catkin");
+        const test = new vscode.Task({ type: "catkin" }, "run_tests", "catkin");
         test.execution = new vscode.ShellExecution(testCommand, {
             env: extension.env,
         });

--- a/src/build-tool/catkin.ts
+++ b/src/build-tool/catkin.ts
@@ -24,7 +24,6 @@ export class CatkinProvider implements vscode.TaskProvider {
     private provideCatkinMakeTasks(): vscode.Task[] {
         const catkinMakeDefinition: vscode.TaskDefinition = {
             type: "catkin_make",
-            target: "build",
         };
         const make = new vscode.Task(catkinMakeDefinition, "build", "catkin_make");
         const buildCommand = `catkin_make --directory "${extension.baseDir}"`;
@@ -36,7 +35,6 @@ export class CatkinProvider implements vscode.TaskProvider {
 
         const catkinMakeRunTestsDefinition: vscode.TaskDefinition = {
             type: "catkin_make",
-            target: "run_tests",
         };
         const test = new vscode.Task(catkinMakeRunTestsDefinition, "run_tests", "catkin_make");
         const testCommand = `${buildCommand} run_tests`;
@@ -51,7 +49,6 @@ export class CatkinProvider implements vscode.TaskProvider {
     private provideCatkinMakeIsolatedTasks(): vscode.Task[] {
         const catkinMakeIsolatedDefinition: vscode.TaskDefinition = {
             type: "catkin_make_isolated",
-            target: "build",
         };
         const make = new vscode.Task(catkinMakeIsolatedDefinition, "build", "catkin_make_isolated");
         const buildCommand = `catkin_make_isolated --directory "${extension.baseDir}"`;
@@ -63,7 +60,6 @@ export class CatkinProvider implements vscode.TaskProvider {
 
         const catkinMakeIsolatedRunTestsDefinition: vscode.TaskDefinition = {
             type: "catkin_make_isolated",
-            target: "run_tests",
         };
         const test = new vscode.Task(catkinMakeIsolatedRunTestsDefinition, "run_tests", "catkin_make_isolated");
         const testCommand = `${buildCommand} --catkin-make-args run_tests`;

--- a/src/build-tool/catkin.ts
+++ b/src/build-tool/catkin.ts
@@ -7,14 +7,12 @@ import * as extension from "../extension";
 import * as common from "./common";
 
 /**
- * Provides catkin build and test tasks
- * including catkin_make and catkin_make_isolated
+ * Provides catkin_make build and test tasks
  */
-export class CatkinProvider implements vscode.TaskProvider {
+export class CatkinMakeProvider implements vscode.TaskProvider {
     public provideTasks(token?: vscode.CancellationToken): vscode.ProviderResult<vscode.Task[]> {
         const tasksCatkinMake = this.provideCatkinMakeTasks();
-        const tasksCatkinMakeIsolated = this.provideCatkinMakeIsolatedTasks();
-        return [...tasksCatkinMake, ...tasksCatkinMakeIsolated];
+        return [...tasksCatkinMake];
     }
 
     public resolveTask(task: vscode.Task, token?: vscode.CancellationToken): vscode.ProviderResult<vscode.Task> {
@@ -44,6 +42,21 @@ export class CatkinProvider implements vscode.TaskProvider {
         test.group = vscode.TaskGroup.Test;
 
         return [make, test];
+    }
+}
+
+/**
+ * Provides catkin_make_isolated build and test tasks
+ */
+// tslint:disable-next-line: max-classes-per-file
+export class CatkinMakeIsolatedProvider implements vscode.TaskProvider {
+    public provideTasks(token?: vscode.CancellationToken): vscode.ProviderResult<vscode.Task[]> {
+        const tasksCatkinMakeIsolated = this.provideCatkinMakeIsolatedTasks();
+        return [...tasksCatkinMakeIsolated];
+    }
+
+    public resolveTask(task: vscode.Task, token?: vscode.CancellationToken): vscode.ProviderResult<vscode.Task> {
+        return undefined;
     }
 
     private provideCatkinMakeIsolatedTasks(): vscode.Task[] {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -142,7 +142,7 @@ function activateEnvironment(context: vscode.ExtensionContext) {
     rosApi.setContext(context, env);
 
     subscriptions.push(rosApi.activateCoreMonitor());
-    subscriptions.push(buildtool.BuildTool.registerTaskProvider());
+    subscriptions.push(...buildtool.BuildTool.registerTaskProvider());
 
     debug_manager.registerRosDebugManager(context);
 


### PR DESCRIPTION
* Defined all the task types in `package.json`.
* Dropped the extra (and reserved) `$` prefix from the name of problem matcher. Otherwise, the vscode will be complaining unexpected object types when it is referred in `tasks.json`.
* Removed the unused `target` attribute to avoid VSCode throwing out errors about `Property target is not allowed` when adding tasks in `tasks.json`.
* Register all task providers by correct types.

fix #126, #114