### PR TITLE
Source the workspace after a ROS build task ends.

### DIFF
--- a/src/build-tool/build-tool.ts
+++ b/src/build-tool/build-tool.ts
@@ -113,3 +113,14 @@ export async function determineBuildTool(dir: string): Promise<boolean> {
     }
     return false;
 }
+
+/**
+ * Check if a task belongs to our extension.
+ * @param task Task to check
+ */
+export function isROSBuildTask(task: vscode.Task) {
+    const types = new Set(["catkin", "catkin_make", "catkin_make_isolated", "colcon"]);
+    const isRosTask = types.has(task.definition.type);
+    const isBuildTask = vscode.TaskGroup.Build === task.group;
+    return isRosTask && isBuildTask;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -178,9 +178,13 @@ function activateEnvironment(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand(Commands.Roslaunch, () => {
             ros_cli.roslaunch(context);
         }),
-
         vscode.commands.registerCommand(Commands.PreviewURDF, () => {
             URDFPreviewManager.INSTANCE.preview(vscode.window.activeTextEditor.document.uri);
+        }),
+        vscode.tasks.onDidEndTask((event: vscode.TaskEndEvent) => {
+            if (buildtool.isROSBuildTask(event.execution.task)) {
+                sourceRosAndWorkspace();
+            }
         }),
     );
 


### PR DESCRIPTION
Source the workspace after a build task ends for convenience. It is useful when there is a change in `devel` space. (For example, in `catkin_make` build, if `bin` was not created at the initial build, but it is created later as you add more code to your project. In such case, you will need to run `devel\setup.bat` again to properly source the environment. Likewise, in `catkin_make_isolated` build, along with more packages added to your workspace, you will need to run `devel_isolated\setup.bat` to exercise newly built isolated packages chain again.)