### PR TITLE
VSIX package doesn't like the SVG asset.

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -36,7 +36,6 @@ jobs:
   archive-vsix:
     runs-on: ubuntu-latest
     needs: [build]
-    if: github.event_name == 'push'
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -51,6 +50,7 @@ jobs:
           npm run compile
           vsce package -o vscode-ros-dev.vsix
       - uses: actions/upload-artifact@v1
+        if: github.event_name == 'push'
         with:
           name: vscode-ros-dev-vsix
           path: vscode-ros-dev.vsix

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Visual Studio Code Extension for ROS
 
-![Build Status][vscode-ros-master-build_status]
-
 The [Visual Studio Code][vscode] Extension for ROS provides support for [Robot Operating System (ROS)][ros] development. Providing an easier and more stream-lined developer experience.
 
 ## Getting Started
@@ -55,10 +53,8 @@ C++ and Python paths. You can re-run this process later using the appropriate co
 
 ### Get Latest Build
 
-[![Build Status][vscode-ros-master-build_status]][vscode-ros-master-build_details]
-
 The lastest unreleased changes could be added by installing the extension's latest build manually.
-To get the latest build (`.vsix` built from the latest commit), access our [build pipeline][vscode-ros-master-build_details] by clicking on the build badge attached above.
+To get the latest build (`.vsix` built from the latest commit), access our [build pipeline][vscode-ros-master-build_details].
 In the build status page, the generated `.vsix` could be downloaded as an artifact:
 
 ![download vsix artifact][download_vsix_artifact]
@@ -100,5 +96,4 @@ Contributions are always welcome! Please see our [contributing guide][contributi
 <!-- link to external sites -->
 [ros]: http://ros.org
 [vscode]: https://code.visualstudio.com
-[vscode-ros-master-build_status]: https://github.com/ms-iot/vscode-ros/workflows/.github/workflows/workflow.yml/badge.svg?branch=master&event=push
 [vscode-ros-master-build_details]: https://github.com/ms-iot/vscode-ros/actions?query=event%3Apush


### PR DESCRIPTION
- Enabling packaging in CI build.
- VSIX package doesn't like SVG in the README.md, so remove it for now.