### PR TITLE
updated to use vscode-webview-resource for vscode 1.47

### DIFF
--- a/src/ros/ros1/core-helper.ts
+++ b/src/ros/ros1/core-helper.ts
@@ -50,12 +50,8 @@ export function launchMonitor(context: vscode.ExtensionContext) {
         }
     );
 
-    let stylesheet = vscode.Uri.file(path.join(context.extensionPath, "assets", "ros", "core-monitor", "style.css")).with({
-        scheme: "vscode-resource"
-    });
-    let script = vscode.Uri.file(path.join(context.extensionPath, "out", "src", "ros", "ros1", "core-monitor", "main.js")).with({
-        scheme: "vscode-resource"
-    });
+    let stylesheet = panel.webview.asWebviewUri(vscode.Uri.file(path.join(context.extensionPath, "assets", "ros", "core-monitor", "style.css")));
+    let script = panel.webview.asWebviewUri(vscode.Uri.file(path.join(context.extensionPath, "out", "src", "ros", "ros1", "core-monitor", "main.js")));
 
     panel.webview.html = getCoreStatusWebviewContent(stylesheet, script);
 

--- a/src/ros/ros2/ros2-monitor.ts
+++ b/src/ros/ros2/ros2-monitor.ts
@@ -30,13 +30,9 @@ export function launchMonitor(context: vscode.ExtensionContext) {
         }
     );
 
-    const stylesheet = vscode.Uri.file(path.join(context.extensionPath, "assets", "ros", "core-monitor", "style.css")).with({
-        scheme: "vscode-resource"
-    });
+    const stylesheet = panel.webview.asWebviewUri(vscode.Uri.file(path.join(context.extensionPath, "assets", "ros", "core-monitor", "style.css")));
 
-    const script = vscode.Uri.file(path.join(context.extensionPath, "out", "src", "ros", "ros2", "webview", "main.js")).with({
-        scheme: "vscode-resource"
-    });
+    const script = panel.webview.asWebviewUri(vscode.Uri.file(path.join(context.extensionPath, "out", "src", "ros", "ros2", "webview", "main.js")));
 
     panel.webview.html = getCoreStatusWebviewContent(stylesheet, script);
 

--- a/src/urdfPreview/preview.ts
+++ b/src/urdfPreview/preview.ts
@@ -129,7 +129,8 @@ export default class URDFPreview
 
                 packagePath = packagePath.substr(1);
             }
-            urdfText = urdfText.replace('package://' + match[1], packagePath);
+            let newUri = this._webview.webview.asWebviewUri(vscode.Uri.file(packagePath));
+            urdfText = urdfText.replace('package://' + match[1], newUri.toString().replace('vscode-webview-resource:', ''));
         }
 
         var previewFile = this._resource.toString();

--- a/src/urdfPreview/preview.ts
+++ b/src/urdfPreview/preview.ts
@@ -121,10 +121,10 @@ export default class URDFPreview
                 // inside of mesh re \source, the loader attempts to concatinate the base uri with the new path. It first checks to see if the
                 // base path has a /, if not it adds it.
                 // We are attempting to use a protocol handler as the base path - which causes this to fail.
-                // basepath - vscode-resource:
+                // basepath - vscode-webview-resource:
                 // full path - /home/test/ros
-                // vscode-resource://home/test/ros.
-                // It should be vscode-resource:/home/test/ros.
+                // vscode-webview-resource://home/test/ros.
+                // It should be vscode-webview-resource:/home/test/ros.
                 // So remove the first char.
 
                 packagePath = packagePath.substr(1);

--- a/templates/preview.html
+++ b/templates/preview.html
@@ -23,12 +23,12 @@
 </style>
 
 
-<script src="http://static.robotwebtools.org/threejs/current/three.js"></script>
-<script src="http://static.robotwebtools.org/threejs/current/ColladaLoader.js"></script>
-<script src="http://static.robotwebtools.org/threejs/current/STLLoader.js"></script>
-<script src="http://static.robotwebtools.org/EventEmitter2/current/eventemitter2.min.js"></script>
-<script src="http://static.robotwebtools.org/roslibjs/current/roslib.js"></script>
-<script src="http://static.robotwebtools.org/ros3djs/current/ros3d.js"></script>
+<script src="https://static.robotwebtools.org/threejs/current/three.js"></script>
+<script src="https://static.robotwebtools.org/threejs/current/ColladaLoader.js"></script>
+<script src="https://static.robotwebtools.org/threejs/current/STLLoader.js"></script>
+<script src="https://static.robotwebtools.org/EventEmitter2/current/eventemitter2.min.js"></script>
+<script src="https://static.robotwebtools.org/roslibjs/current/roslib.js"></script>
+<script src="https://static.robotwebtools.org/ros3djs/current/ros3d.js"></script>
 
 <script>
     
@@ -54,14 +54,14 @@ function applyURDF(urdfText) {
 
     window.urdfModel = new ROSLIB.UrdfModel({
         string : urdfText,
-        path: "vscode-resource:"
+        path: "vscode-webview-resource:"
       });
 
     var tfClient = new TFFakeClient();
 
     window.urdfScene = new ROS3D.Urdf({
       urdfModel : window.urdfModel,
-      path : "vscode-resource:",
+      path: "vscode-webview-resource:",
       tfClient : tfClient,
       loader : ROS3D.COLLADA_LOADER_2
     });


### PR DESCRIPTION
Since vscode 1.47, the usage of `vscode-resource` will be generating errors and it recommended to migrating to `vscode-webview-resource`. And also now it is recommended to use `https` to access the external resource.

Fixes #261 and #214.