### PR TITLE
Allow customization of build tool tasks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,5 @@
     "search.exclude": {
         "out": true // set this to false to include "out" folder in search results
     },
-    "typescript.tsdk": "./node_modules/typescript/lib", // we want to use the TS server from our node_modules folder to control its version
-    "python.pythonPath": "C:\\opt\\python27amd64\\python.exe"
+    "typescript.tsdk": "./node_modules/typescript/lib"
 }

--- a/doc/debug-support.md
+++ b/doc/debug-support.md
@@ -41,6 +41,96 @@ The launch-debug flow provided by `vscode-ros` will not spawn a `rosmaster`.
 
 ![launch and debug Python and C++ nodes][launch_and_debug_nodes]
 
+### <a name="build_tasks"></a> Use tasks to automatically build before starting debug session
+
+The first thing you need to do is to create build task for your package(s) with enabled debug symbols. 
+In the example below you can see a `catkin_make` build task that passes additional `-DCMAKE_BUILD_TYPE=Debug` argument that switches build to use `Debug` configuration, which is the most suitable configuration for debugging, because it has 0 optimization level and includes debug symbols.
+**Note: you might need to remove the old `build` folder to force rebuild in new configuraiton.**
+
+```json5
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "make_debug",
+            "type": "catkin_make",
+            "args": [
+                "--directory",
+                "${workspaceFolder}",
+                "-DCMAKE_BUILD_TYPE=Debug", // This extra argument enables built with debug symbols
+            ],
+            "problemMatcher": [
+                "$catkin-gcc"
+            ],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+        },
+    ]
+}
+```
+
+The next step would be to configure `.vscode/launch.json` and customize `preLaunchTask` to use `make_debug` task we created above.
+
+```json5
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "ROS: Launch",
+            "type": "ros",
+            "request": "launch",
+            "target": "${workspaceFolder}/launch/some.launch", // <<< Configure path to your launch file
+            "preLaunchTask": "make_debug", // <<< This is the task that will run before debugging starts
+        }
+    ]
+}
+
+```
+
+
+
+
+### Use tasks to automatically build and start rosmaster
+
+**This is current BLOCKED BY VSCode Bug [70283][ms-vscode.background_bug]. This bug will prevent the second debugging session from starting if roscore background task is already running**
+
+This section continues setup that was described [above](#build_tasks), so please complete that section and ensure you can build and debug with manually started roscore 
+
+We are going to define a new task named `make_debug_and_core` that is going to start both `make_debug` and `roscore: roscore` tasks. `roscore: roscore` is a background task that will continue running even after debuging session is over
+
+```json5
+{
+    "version": "2.0.0",
+    "tasks": [
+        /// ... `make_debug` task definition as before
+        {
+            "label": "make_debug_and_core",
+            "dependsOn": [
+                "make_debug",
+                "roscore: roscore", // This task is provided by vscode-ros
+            ]
+        },
+    ]
+}
+```
+
+The next step would be to switch `preLaunchTask` to use `make_debug_and_core` task we created above.
+
+```json5
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            // ... same as before
+            "preLaunchTask": "make_debug_and_core",
+        }
+    ]
+}
+
+```
+
 ## Note
 
 1. Debugging functionality provided by `vscode-ros` has dependencies on VS Code’s [C++][ms-vscode.cpptools] and [Python][ms-python.python] extensions, and those have dependencies on the version of VS Code. To ensure everything works as expected, please make sure to have everything up-to-date.
@@ -62,3 +152,4 @@ The launch-debug flow provided by `vscode-ros` will not spawn a `rosmaster`.
 
 [ms-python.python]: https://marketplace.visualstudio.com/items?itemName=ms-python.python
 [ms-vscode.cpptools]: https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools
+[ms-vscode.background_bug]: https://github.com/microsoft/vscode/issues/70283

--- a/doc/debug-support.md
+++ b/doc/debug-support.md
@@ -44,7 +44,8 @@ The launch-debug flow provided by `vscode-ros` will not spawn a `rosmaster`.
 ### <a name="build_tasks"></a> Use tasks to automatically build before starting debug session
 
 The first thing you need to do is to create build task for your package(s) with enabled debug symbols. 
-In the example below you can see a `catkin_make` build task that passes additional `-DCMAKE_BUILD_TYPE=Debug` argument that switches build to use `Debug` configuration, which is the most suitable configuration for debugging, because it has 0 optimization level and includes debug symbols.
+In the example below you can see a `catkin_make` build task that passes additional `-DCMAKE_BUILD_TYPE=Debug`  argument that switches build to use `Debug` configuration, which is the most suitable configuration for debugging, because it has 0 optimization level and includes debug symbols. Another option is to use `-DCMAKE_BUILD_TYPE=RelWithDebInfo` that also enables debug symbols, but uses `Release` settings for everything else and has optimizations enabled. `RelWithDebInfo` might be a go to build configuration for Windows users in order to avoid slowness of the debug CRT on Windows OS. You can read more about [CMAKE_BUILD_TYPE here][stackoverflow-cmake_build_type]
+
 **Note: you might need to remove the old `build` folder to force rebuild in new configuraiton.**
 
 ```json5
@@ -134,7 +135,7 @@ The next step would be to switch `preLaunchTask` to use `make_debug_and_core` ta
 ## Note
 
 1. Debugging functionality provided by `vscode-ros` has dependencies on VS Code’s [C++][ms-vscode.cpptools] and [Python][ms-python.python] extensions, and those have dependencies on the version of VS Code. To ensure everything works as expected, please make sure to have everything up-to-date.
-2. To debug a C++ executable, please make sure the binary is [built with debug symbols][ros_answers_debug_symbol] (e.g. `-DCMAKE_BUILD_TYPE=RelWithDebInfo`).
+2. To debug a C++ executable, please make sure the binary is [built with debug symbols][ros_answers_debug_symbol] (e.g. `-DCMAKE_BUILD_TYPE=RelWithDebInfo`, read more about [CMAKE_BUILD_TYPE here][stackoverflow-cmake_build_type]).
 3. To use VS Code's C++ extension with MSVC on Windows, please make sure the VS Code instance is launched from a Visual Studio command prompt.
 
 <!-- link to files -->
@@ -153,3 +154,4 @@ The next step would be to switch `preLaunchTask` to use `make_debug_and_core` ta
 [ms-python.python]: https://marketplace.visualstudio.com/items?itemName=ms-python.python
 [ms-vscode.cpptools]: https://marketplace.visualstudio.com/items?itemName=ms-vscode.cpptools
 [ms-vscode.background_bug]: https://github.com/microsoft/vscode/issues/70283
+[stackoverflow-cmake_build_type]: https://stackoverflow.com/a/59314670/888545

--- a/package.json
+++ b/package.json
@@ -251,7 +251,7 @@
                 "background": {
                     "activeOnStart": true,
                     "beginsPattern": ".",
-                    "endsPattern": "(process[master]: started with pid|master is already running)"
+                    "endsPattern": "(process\\[master\\]: started with pid|roscore cannot run|master is already running)"
                 }
             },
             {

--- a/package.json
+++ b/package.json
@@ -239,20 +239,89 @@
                     "severity": 4,
                     "message": 5
                 }
+            },
+            {
+                "name": "roscore",
+                "pattern": {
+                    "regexp": ".",
+                    "file": 1,
+                    "line": 2,
+                    "message": 3
+                },
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": ".",
+                    "endsPattern": "(process[master]: started with pid|master is already running)"
+                }
+            },
+            {
+                "name": "roslaunch",
+                "pattern": {
+                    "regexp": "^(.*):\\s+(.*):\\s+line\\s+(\\d+),\\s+column\\s+(\\d+)$",
+                    "line": 3,
+                    "column": 4,
+                    "message": 2,
+                    "severity": 1
+                },
+                "background": {
+                    "activeOnStart": true,
+                    "beginsPattern": "started roslaunch server",
+                    "endsPattern": "ROS_MASTER_URI="
+                }
             }
         ],
         "taskDefinitions": [
             {
-                "type": "catkin_make"
+                "type": "ros",
+                "required": [
+                    "command"
+                ],
+                "properties": {
+                    "command": {
+                        "type": "string",
+                        "description": "command to execute in ROS environment"
+                    },
+                    "args": {
+                        "type": "array",
+                        "description": "Commadn line arguments to command"
+                    }
+                }
             },
             {
-                "type": "catkin_make_isolated"
+                "type": "catkin_make",
+                "properties": {
+                    "args": {
+                        "type": "array",
+                        "description": "Commadn line arguments to catkin_make"
+                    }
+                }
             },
             {
-                "type": "catkin"
+                "type": "catkin_make_isolated",
+                "properties": {
+                    "args": {
+                        "type": "array",
+                        "description": "Commadn line arguments to catkin_make_isolated"
+                    }
+                }
             },
             {
-                "type": "colcon"
+                "type": "catkin",
+                "properties": {
+                    "args": {
+                        "type": "array",
+                        "description": "Commadn line arguments to catkin"
+                    }
+                }
+            },
+            {
+                "type": "colcon",
+                "properties": {
+                    "args": {
+                        "type": "array",
+                        "description": "Commadn line arguments to colcon"
+                    }
+                }
             }
         ]
     },

--- a/src/build-tool/catkin.ts
+++ b/src/build-tool/catkin.ts
@@ -5,83 +5,48 @@ import * as vscode from "vscode";
 
 import * as extension from "../extension";
 import * as common from "./common";
+import * as rosShell from "./ros-shell";
 
+function makeCatkin(command: string, args: string[], category?: string): vscode.Task {
+    const task = rosShell.make({type: command, command, args: ['--directory', extension.baseDir, ...args]}, category)
+    task.problemMatchers = ["$catkin-gcc"];
+
+    return task;
+}
 /**
  * Provides catkin_make build and test tasks
  */
 export class CatkinMakeProvider implements vscode.TaskProvider {
     public provideTasks(token?: vscode.CancellationToken): vscode.ProviderResult<vscode.Task[]> {
-        const tasksCatkinMake = this.provideCatkinMakeTasks();
-        return [...tasksCatkinMake];
-    }
-
-    public resolveTask(task: vscode.Task, token?: vscode.CancellationToken): vscode.ProviderResult<vscode.Task> {
-        return undefined;
-    }
-
-    private provideCatkinMakeTasks(): vscode.Task[] {
-        const catkinMakeDefinition: vscode.TaskDefinition = {
-            type: "catkin_make",
-        };
-        const make = new vscode.Task(catkinMakeDefinition, "build", "catkin_make");
-        const buildCommand = `catkin_make --directory "${extension.baseDir}"`;
-        make.execution = new vscode.ShellExecution(buildCommand, {
-            env: extension.env,
-        });
+        const make = makeCatkin('catkin_make', [], 'build');
         make.group = vscode.TaskGroup.Build;
-        make.problemMatchers = ["$catkin-gcc"];
 
-        const catkinMakeRunTestsDefinition: vscode.TaskDefinition = {
-            type: "catkin_make",
-        };
-        const test = new vscode.Task(catkinMakeRunTestsDefinition, "run_tests", "catkin_make");
-        const testCommand = `${buildCommand} run_tests`;
-        test.execution = new vscode.ShellExecution(testCommand, {
-            env: extension.env,
-        });
+        const test = makeCatkin('catkin_make', ['run_tests'], 'run_tests');
         test.group = vscode.TaskGroup.Test;
 
         return [make, test];
+    }
+
+    public resolveTask(task: vscode.Task, token?: vscode.CancellationToken): vscode.ProviderResult<vscode.Task> {
+        return rosShell.resolve(task);
     }
 }
-
 /**
- * Provides catkin_make_isolated build and test tasks
+ * Provides catkin_make build and test tasks
  */
-// tslint:disable-next-line: max-classes-per-file
 export class CatkinMakeIsolatedProvider implements vscode.TaskProvider {
     public provideTasks(token?: vscode.CancellationToken): vscode.ProviderResult<vscode.Task[]> {
-        const tasksCatkinMakeIsolated = this.provideCatkinMakeIsolatedTasks();
-        return [...tasksCatkinMakeIsolated];
-    }
-
-    public resolveTask(task: vscode.Task, token?: vscode.CancellationToken): vscode.ProviderResult<vscode.Task> {
-        return undefined;
-    }
-
-    private provideCatkinMakeIsolatedTasks(): vscode.Task[] {
-        const catkinMakeIsolatedDefinition: vscode.TaskDefinition = {
-            type: "catkin_make_isolated",
-        };
-        const make = new vscode.Task(catkinMakeIsolatedDefinition, "build", "catkin_make_isolated");
-        const buildCommand = `catkin_make_isolated --directory "${extension.baseDir}"`;
-        make.execution = new vscode.ShellExecution(buildCommand, {
-            env: extension.env,
-        });
+        const make = makeCatkin('catkin_make_isolated', [], 'build');
         make.group = vscode.TaskGroup.Build;
-        make.problemMatchers = ["$catkin-gcc"];
 
-        const catkinMakeIsolatedRunTestsDefinition: vscode.TaskDefinition = {
-            type: "catkin_make_isolated",
-        };
-        const test = new vscode.Task(catkinMakeIsolatedRunTestsDefinition, "run_tests", "catkin_make_isolated");
-        const testCommand = `${buildCommand} --catkin-make-args run_tests`;
-        test.execution = new vscode.ShellExecution(testCommand, {
-            env: extension.env,
-        });
+        const test = makeCatkin('catkin_make_isolated', ['--catkin-make-args', 'run_tests'], 'run_tests');
         test.group = vscode.TaskGroup.Test;
 
         return [make, test];
+    }
+
+    public resolveTask(task: vscode.Task, token?: vscode.CancellationToken): vscode.ProviderResult<vscode.Task> {
+        return rosShell.resolve(task);
     }
 }
 

--- a/src/build-tool/catkin.ts
+++ b/src/build-tool/catkin.ts
@@ -32,7 +32,7 @@ export class CatkinMakeProvider implements vscode.TaskProvider {
     }
 }
 /**
- * Provides catkin_make build and test tasks
+ * Provides catkin_make_isolated build and test tasks
  */
 export class CatkinMakeIsolatedProvider implements vscode.TaskProvider {
     public provideTasks(token?: vscode.CancellationToken): vscode.ProviderResult<vscode.Task[]> {

--- a/src/build-tool/colcon.ts
+++ b/src/build-tool/colcon.ts
@@ -1,47 +1,46 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-import * as child_process from "child_process";
 import * as vscode from "vscode";
 
+import * as child_process from "child_process";
 import * as extension from "../extension";
+import * as common from "./common";
+import * as rosShell from "./ros-shell";
+
+function makeColcon(command: string, args: string[], category?: string): vscode.Task {
+    const task = rosShell.make({type: command, command, args: ['--workspace', extension.baseDir, ...args]}, category)
+
+    return task;
+}
 
 /**
- * Provides colcon build and test tasks.
+ * Provides catkin tools build and test tasks.
  */
 export class ColconProvider implements vscode.TaskProvider {
     public provideTasks(token?: vscode.CancellationToken): vscode.ProviderResult<vscode.Task[]> {
-        const buildCommand = "colcon build";
-        const testCommand = "colcon test";
+        const make = makeColcon('colcon', ['build'], 'build');
+        make.group = vscode.TaskGroup.Build;
 
-        const build = new vscode.Task(
-            { type: "colcon" },
-            vscode.TaskScope.Workspace,
-            "build",
-            "colcon",
-            new vscode.ShellExecution(buildCommand, {
-                env: extension.env,
-            }),
-            []);
-        build.group = vscode.TaskGroup.Build;
-
-        const test = new vscode.Task(
-            { type: "colcon" },
-            vscode.TaskScope.Workspace,
-            "test",
-            "colcon",
-            new vscode.ShellExecution(testCommand, {
-                env: extension.env,
-            }),
-            []);
+        const test = makeColcon('colcon', ['test'], 'test');
         test.group = vscode.TaskGroup.Test;
 
-        return [build, test];
+        return [make, test];
     }
 
     public resolveTask(task: vscode.Task, token?: vscode.CancellationToken): vscode.ProviderResult<vscode.Task> {
-        return undefined;
+        return rosShell.resolve(task);
     }
+}
+
+/**
+ * Interacts with the user to run a `catkin create pkg` command.
+ */
+export async function createPackage(uri?: vscode.Uri) {
+    const createPkgCommand = (dependencies: string, name: string): string => {
+        return `catkin create pkg --catkin-deps ${dependencies} -- ${name}`;
+    };
+    return common._createPackage(createPkgCommand);
 }
 
 export async function isApplicable(dir: string): Promise<boolean> {

--- a/src/build-tool/colcon.ts
+++ b/src/build-tool/colcon.ts
@@ -15,7 +15,7 @@ function makeColcon(command: string, args: string[], category?: string): vscode.
 }
 
 /**
- * Provides catkin tools build and test tasks.
+ * Provides colcon build and test tasks.
  */
 export class ColconProvider implements vscode.TaskProvider {
     public provideTasks(token?: vscode.CancellationToken): vscode.ProviderResult<vscode.Task[]> {
@@ -31,16 +31,6 @@ export class ColconProvider implements vscode.TaskProvider {
     public resolveTask(task: vscode.Task, token?: vscode.CancellationToken): vscode.ProviderResult<vscode.Task> {
         return rosShell.resolve(task);
     }
-}
-
-/**
- * Interacts with the user to run a `catkin create pkg` command.
- */
-export async function createPackage(uri?: vscode.Uri) {
-    const createPkgCommand = (dependencies: string, name: string): string => {
-        return `catkin create pkg --catkin-deps ${dependencies} -- ${name}`;
-    };
-    return common._createPackage(createPkgCommand);
 }
 
 export async function isApplicable(dir: string): Promise<boolean> {

--- a/src/build-tool/ros-shell.ts
+++ b/src/build-tool/ros-shell.ts
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+import * as vscode from "vscode";
+
+import * as extension from "../extension";
+
+export interface RosTaskDefinition extends vscode.TaskDefinition {
+    command: string;
+    args?: string[];
+}
+
+export class RosShellTaskProvider implements vscode.TaskProvider {
+    public provideTasks(token?: vscode.CancellationToken): vscode.ProviderResult<vscode.Task[]> {
+        return this.defaultRosTasks();
+    }
+
+    public defaultRosTasks(): vscode.Task[] {
+        const rosCore = make({type: 'ros', command: 'roscore'}, 'roscore');
+        rosCore.isBackground = true;
+        rosCore.problemMatchers = ['$roscore'];
+
+        const rosLaunch = make({type: 'ros', command: 'roslaunch', args: ['package_name', 'launch_file.launch']}, 'roslaunch');
+        rosLaunch.isBackground = true;
+        rosLaunch.problemMatchers = ['$roslaunch'];
+
+        return [rosCore, rosLaunch];
+    }
+
+    public resolveTask(task: vscode.Task, token?: vscode.CancellationToken): vscode.ProviderResult<vscode.Task> {
+        return resolve(task);
+    }
+}
+
+export function registerRosShellTaskProvider(): vscode.Disposable[] {
+    return [
+        vscode.tasks.registerTaskProvider('ros', new RosShellTaskProvider()),
+    ];
+}
+
+export function resolve(task: vscode.Task): vscode.Task {
+    const resolvedTask = make(task.definition as RosTaskDefinition);
+
+    resolvedTask.isBackground = task.isBackground;
+    resolvedTask.problemMatchers = task.problemMatchers;
+    return resolvedTask;
+}
+
+export function make(definition: RosTaskDefinition, category?: string): vscode.Task {
+    definition.command = definition.command || definition.type; // Command can be missing in build tasks that have type==command
+
+    const args = definition.args || [];
+    const name = category ? category : args.join(' ');
+    const task = new vscode.Task(definition, vscode.TaskScope.Workspace, name, definition.command);
+
+    task.execution = new vscode.ShellExecution(definition.command, args, {
+        env: extension.env,
+    });
+    return task;
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -19,6 +19,7 @@ import URDFPreviewManager from "./urdfPreview/previewManager"
 
 import * as debug_manager from "./debugger/manager";
 import * as debug_utils from "./debugger/utils";
+import { registerRosShellTaskProvider } from "./build-tool/ros-shell";
 
 /**
  * The catkin workspace base dir.
@@ -152,6 +153,7 @@ function activateEnvironment(context: vscode.ExtensionContext) {
 
     subscriptions.push(rosApi.activateCoreMonitor());
     subscriptions.push(...buildtool.BuildTool.registerTaskProvider());
+    subscriptions.push(...registerRosShellTaskProvider());
 
     debug_manager.registerRosDebugManager(context);
 


### PR DESCRIPTION
Implements #305

Add args parameter to all build tool tasks that allows customization in the workspaces's tasks.json by users
Implement generic task named `ros`
Add `roscore` and `roslaunch` commands using `ros` task that allows user to run and customize them in tasks.json
