### PR TITLE
Have executable search follow symbolic links

### DIFF
--- a/src/ros/ros1/ros1.ts
+++ b/src/ros/ros1/ros1.ts
@@ -105,7 +105,7 @@ export class ROS1 implements ros.ROSApi {
             return this._findPackageFiles(packageName, `--libexec`, `*.exe`);
         } else {
             const dirs = `catkin_find --without-underlays --libexec --share '${packageName}'`;
-            command = `find $(${dirs}) -type f -executable`;
+            command = `find -L $(${dirs}) -type f -executable`;
             return new Promise((c, e) => child_process.exec(command, { env: this.env }, (err, out) =>
                 err ? e(err) : c(out.trim().split(os.EOL)),
             ));
@@ -118,7 +118,7 @@ export class ROS1 implements ros.ROSApi {
             return this._findPackageFiles(packageName, `--share`, `*.launch`);
         } else {
             const dirs = `catkin_find --without-underlays --share '${packageName}'`;
-            command = `find $(${dirs}) -type f -name *.launch`;
+            command = `find -L $(${dirs}) -type f -name *.launch`;
         }
 
         return new Promise((c, e) => child_process.exec(command, { env: this.env }, (err, out) => {


### PR DESCRIPTION
This fixes issue #184 
It makes the plugin work with catkin build commands, which make use of symbolic links to the executable.