### PR TITLE
[ROS2] Adding Initial ROS2 Launch Debug Support

### DIFF
--- a/THIRD_PARTY_NOTICE.md
+++ b/THIRD_PARTY_NOTICE.md
@@ -61,3 +61,242 @@ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
 ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 ```
+## `ros2/launch` ORIGINAL LICENSE
+```
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+
+
+----------------------------
+
+
+
+  Software License Agreement (BSD License)
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+   * Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+     copyright notice, this list of conditions and the following
+     disclaimer in the documentation and/or other materials provided
+     with the distribution.
+   * Neither the name of Willow Garage, Inc. nor the names of its
+     contributors may be used to endorse or promote products derived
+     from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+  POSSIBILITY OF SUCH DAMAGE.
+```

--- a/assets/scripts/ros2_launch_dumper.py
+++ b/assets/scripts/ros2_launch_dumper.py
@@ -101,6 +101,10 @@ if __name__ == "__main__":
     context._set_asyncio_loop(asyncio.get_event_loop())
 
     try:
+        # * Here we mimic the run loop inside launch_service,
+        #   but without actually kicking off the processes.
+        # * Traverse the sub entities by DFS.
+        # * Shadow the stdout to avoid random print outputs.
         mystring = StringIO()
         sys.stdout = mystring
         while walker:

--- a/package.json
+++ b/package.json
@@ -121,8 +121,16 @@
                             },
                             "args": {
                                 "type": "array",
-                                "description": "Arguments for the roslaunch command",
+                                "description": "Arguments for the roslaunch (or ros2 launch) command",
                                 "default": []
+                            },
+                            "env": {
+                                "type": "object",
+                                "description": "Environment variables defined as a key value pair. Property ends up being the Environment Variable and the value of the property ends up being the value of the Env Variable.",
+                                "default": {},
+                                "additionalProperties": {
+                                    "type": "string"
+                                }
                             }
                         }
                     },

--- a/src/debugger/configuration/resolvers/ros1/launch.ts
+++ b/src/debugger/configuration/resolvers/ros1/launch.ts
@@ -12,9 +12,9 @@ import * as tmp from "tmp";
 import * as util from "util";
 import * as vscode from "vscode";
 
-import * as extension from "../../../extension";
-import * as requests from "../../requests";
-import * as utils from "../../utils";
+import * as extension from "../../../../extension";
+import * as requests from "../../../requests";
+import * as utils from "../../../utils";
 
 const promisifiedExec = util.promisify(child_process.exec);
 

--- a/src/debugger/configuration/resolvers/ros1/launch.ts
+++ b/src/debugger/configuration/resolvers/ros1/launch.ts
@@ -143,6 +143,7 @@ export class LaunchResolver implements vscode.DebugConfigurationProvider {
                     args: request.arguments,
                     env: request.env,
                     stopOnEntry: stopOnEntry,
+                    justMyCode: false,
                 };
                 debugConfig = pythonLaunchConfig;
             } else if (request.executable.endsWith(".exe")) {
@@ -221,6 +222,7 @@ export class LaunchResolver implements vscode.DebugConfigurationProvider {
                         args: request.arguments,
                         env: request.env,
                         stopOnEntry: stopOnEntry,
+                        justMyCode: false,
                     };
                     debugConfig = pythonLaunchConfig;
                 } else {

--- a/src/debugger/configuration/resolvers/ros2/launch.ts
+++ b/src/debugger/configuration/resolvers/ros2/launch.ts
@@ -104,17 +104,16 @@ export class LaunchResolver implements vscode.DebugConfigurationProvider {
         let debugConfig: ICppvsdbgLaunchConfiguration | ICppdbgLaunchConfiguration | IPythonLaunchConfiguration;
 
         if (os.platform() === "win32") {
-            if (request.executable.toLowerCase().endsWith("python") ||
-                request.executable.toLowerCase().endsWith("python.exe")) {
-                const pythonScript: string = request.arguments.shift();
+            if (request.executable.toLowerCase().endsWith(".py")) {
                 const pythonLaunchConfig: IPythonLaunchConfiguration = {
                     name: request.nodeName,
                     type: "python",
                     request: "launch",
-                    program: pythonScript,
+                    program: request.executable,
                     args: request.arguments,
                     env: request.env,
                     stopOnEntry: stopOnEntry,
+                    justMyCode: false,
                 };
                 debugConfig = pythonLaunchConfig;
             } else if (request.executable.toLowerCase().endsWith(".exe")) {
@@ -193,6 +192,7 @@ export class LaunchResolver implements vscode.DebugConfigurationProvider {
                         args: request.arguments,
                         env: request.env,
                         stopOnEntry: stopOnEntry,
+                        justMyCode: false,
                     };
                     debugConfig = pythonLaunchConfig;
                 } else {

--- a/src/debugger/configuration/resolvers/ros2/launch.ts
+++ b/src/debugger/configuration/resolvers/ros2/launch.ts
@@ -1,0 +1,238 @@
+// Copyright (c) Andrew Short. All rights reserved.
+// Licensed under the MIT License.
+
+import * as child_process from "child_process";
+import * as fs from "fs";
+import * as yaml from "js-yaml";
+import * as os from "os";
+import * as path from "path";
+import * as readline from "readline";
+import * as shell_quote from "shell-quote";
+import * as tmp from "tmp";
+import * as util from "util";
+import * as vscode from "vscode";
+
+import * as extension from "../../../../extension";
+import * as requests from "../../../requests";
+import * as utils from "../../../utils";
+
+const promisifiedExec = util.promisify(child_process.exec);
+
+interface ILaunchRequest {
+    nodeName: string;
+    executable: string;
+    arguments: string[];
+    cwd: string;
+    env: { [key: string]: string };
+}
+
+function getExtensionFilePath(extensionFile: string): string {
+    return path.resolve(extension.extPath, extensionFile);
+}
+
+export class LaunchResolver implements vscode.DebugConfigurationProvider {
+    // tslint:disable-next-line: max-line-length
+    public async resolveDebugConfigurationWithSubstitutedVariables(folder: vscode.WorkspaceFolder | undefined, config: requests.ILaunchRequest, token?: vscode.CancellationToken) {
+        if (!path.isAbsolute(config.target) || path.extname(config.target) !== ".py") {
+            throw new Error("Launch request requires an absolute path as target.");
+        }
+
+        const rosExecOptions: child_process.ExecOptions = {
+            env: await extension.resolvedEnv(),
+        };
+
+        let ros2_launch_dumper = getExtensionFilePath(path.join("assets", "scripts", "ros2_launch_dumper.py"));
+
+        let args = []
+        for (let arg of config.args) {
+            args.push(`"${arg}"`);
+        }
+        let flatten_args = args.join(' ')
+
+        let result = await promisifiedExec(`python ${ros2_launch_dumper} "${config.target}" ${flatten_args}`, rosExecOptions);
+        if (result.stderr) {
+            throw (new Error(`Error from ROS2 launch dumper:\r\n ${result.stderr}`));
+        } else if (result.stdout.length == 0) {
+            throw (new Error(`ROS2 launch dumper unexpectedly produced no output.`));
+        }
+
+        let commands = result.stdout.split(os.EOL);
+        commands.forEach((command) => {
+            if (!command)
+                return;
+            let process = command.split(' ')[0];
+            const launchRequest = this.generateLaunchRequest(process, command);
+            this.executeLaunchRequest(launchRequest, false);
+        });
+
+        // @todo: error handling for Promise.all
+
+        // Return null as we have spawned new debug requests
+        return null;
+    }
+
+
+    private generateLaunchRequest(nodeName: string, command: string): ILaunchRequest {
+        let parsedArgs: shell_quote.ParseEntry[];
+        const isWindows = os.platform() === "win32";
+
+        if (isWindows) {
+            // https://github.com/ros/ros_comm/pull/1809
+            // escape backslash in file path
+            // parsedArgs = shell_quote.parse(command.replace(/[\\]/g, "\\$&"));
+            // parsedArgs = shell_quote.parse(parsedArgs[2].toString().replace(/[\\]/g, "\\$&"));
+            parsedArgs = shell_quote.parse(command);
+        } else {
+            parsedArgs = shell_quote.parse(command);
+        }
+
+        const envConfig: { [key: string]: string; } = {};
+
+        const request: ILaunchRequest = {
+            nodeName: nodeName,
+            executable: parsedArgs.shift().toString(),
+            arguments: parsedArgs.map((arg) => {
+                return arg.toString();
+            }),
+            cwd: ".",
+            env: {
+                ...extension.env,
+                ...envConfig,
+            },
+        };
+        return request;
+    }
+
+    private async executeLaunchRequest(request: ILaunchRequest, stopOnEntry: boolean) {
+        let debugConfig: ICppvsdbgLaunchConfiguration | ICppdbgLaunchConfiguration | IPythonLaunchConfiguration;
+
+        if (os.platform() === "win32") {
+            if (request.executable.toLowerCase().endsWith("python") ||
+                request.executable.toLowerCase().endsWith("python.exe")) {
+                const pythonScript: string = request.arguments.shift();
+                const pythonLaunchConfig: IPythonLaunchConfiguration = {
+                    name: request.nodeName,
+                    type: "python",
+                    request: "launch",
+                    program: pythonScript,
+                    args: request.arguments,
+                    env: request.env,
+                    stopOnEntry: stopOnEntry,
+                };
+                debugConfig = pythonLaunchConfig;
+            } else if (request.executable.toLowerCase().endsWith(".exe")) {
+                interface ICppEnvConfig {
+                    name: string;
+                    value: string;
+                }
+                const envConfigs: ICppEnvConfig[] = [];
+                for (const key in request.env) {
+                    if (request.env.hasOwnProperty(key)) {
+                        envConfigs.push({
+                            name: key,
+                            value: request.env[key],
+                        });
+                    }
+                }
+                const cppvsdbgLaunchConfig: ICppvsdbgLaunchConfiguration = {
+                    name: request.nodeName,
+                    type: "cppvsdbg",
+                    request: "launch",
+                    cwd: ".",
+                    program: request.executable,
+                    args: request.arguments,
+                    environment: envConfigs,
+                    stopAtEntry: stopOnEntry,
+                };
+                debugConfig = cppvsdbgLaunchConfig;
+            }
+
+            if (!debugConfig) {
+                throw (new Error(`Failed to create a debug configuration!`));
+            }
+            const launched = await vscode.debug.startDebugging(undefined, debugConfig);
+            if (!launched) {
+                throw (new Error(`Failed to start debug session!`));
+            }
+        } else {
+            try {
+                // this should be guaranteed by roslaunch
+                fs.accessSync(request.executable, fs.constants.X_OK);
+            } catch (errNotExecutable) {
+                throw (new Error(`Error! ${request.executable} is not executable!`));
+            }
+
+            try {
+                // need to be readable to check shebang line
+                fs.accessSync(request.executable, fs.constants.R_OK);
+            } catch (errNotReadable) {
+                throw (new Error(`Error! ${request.executable} is not readable!`));
+            }
+
+            const fileStream = fs.createReadStream(request.executable);
+            const rl = readline.createInterface({
+                input: fileStream,
+                crlfDelay: Infinity,
+            });
+
+            // we only want to read 1 line to check for shebang line
+            let linesToRead: number = 1;
+            rl.on("line", async (line) => {
+                if (linesToRead <= 0) {
+                    return;
+                }
+                linesToRead--;
+                if (!linesToRead) {
+                    rl.close();
+                }
+
+                // look for Python in shebang line
+                if (line.startsWith("#!") && line.toLowerCase().indexOf("python") !== -1) {
+                    const pythonLaunchConfig: IPythonLaunchConfiguration = {
+                        name: request.nodeName,
+                        type: "python",
+                        request: "launch",
+                        program: request.executable,
+                        args: request.arguments,
+                        env: request.env,
+                        stopOnEntry: stopOnEntry,
+                    };
+                    debugConfig = pythonLaunchConfig;
+                } else {
+                    interface ICppEnvConfig {
+                        name: string;
+                        value: string;
+                    }
+                    const envConfigs: ICppEnvConfig[] = [];
+                    for (const key in request.env) {
+                        if (request.env.hasOwnProperty(key)) {
+                            envConfigs.push({
+                                name: key,
+                                value: request.env[key],
+                            });
+                        }
+                    }
+                    const cppdbgLaunchConfig: ICppdbgLaunchConfiguration = {
+                        name: request.nodeName,
+                        type: "cppdbg",
+                        request: "launch",
+                        cwd: ".",
+                        program: request.executable,
+                        args: request.arguments,
+                        environment: envConfigs,
+                        stopAtEntry: stopOnEntry,
+                    };
+                    debugConfig = cppdbgLaunchConfig;
+                }
+
+                if (!debugConfig) {
+                    throw (new Error(`Failed to create a debug configuration!`));
+                }
+                const launched = await vscode.debug.startDebugging(undefined, debugConfig);
+                if (!launched) {
+                    throw (new Error(`Failed to start debug session!`));
+                }
+            });
+        }
+    }
+}

--- a/src/debugger/configuration/resolvers/ros2/launch.ts
+++ b/src/debugger/configuration/resolvers/ros2/launch.ts
@@ -51,8 +51,11 @@ export class LaunchResolver implements vscode.DebugConfigurationProvider {
             args.push(`"${arg}"`);
         }
         let flatten_args = args.join(' ')
+        let ros2_launch_dumper_cmdLine = (process.platform === "win32") ?
+            `python ${ros2_launch_dumper} "${config.target}" ${flatten_args}` :
+            `/usr/bin/env python3 ${ros2_launch_dumper} "${config.target}" ${flatten_args}`;
 
-        let result = await promisifiedExec(`python ${ros2_launch_dumper} "${config.target}" ${flatten_args}`, rosExecOptions);
+        let result = await promisifiedExec(ros2_launch_dumper_cmdLine, rosExecOptions);
         if (result.stderr) {
             throw (new Error(`Error from ROS2 launch dumper:\r\n ${result.stderr}`));
         } else if (result.stdout.length == 0) {

--- a/src/debugger/manager.ts
+++ b/src/debugger/manager.ts
@@ -5,18 +5,22 @@ import * as vscode from "vscode";
 
 import * as ros_provider from "./configuration/providers/ros";
 import * as attach_resolver from "./configuration/resolvers/attach";
-import * as launch_resolver from "./configuration/resolvers/launch";
+import * as ros1_launch_resolver from "./configuration/resolvers/ros1/launch";
+import * as ros2_launch_resolver from "./configuration/resolvers/ros2/launch";
 import * as requests from "./requests";
+import * as extension from "../extension";
 
 class RosDebugManager implements vscode.DebugConfigurationProvider {
     private configProvider: ros_provider.RosDebugConfigurationProvider;
     private attachResolver: attach_resolver.AttachResolver;
-    private launchResolver: launch_resolver.LaunchResolver;
+    private ros1LaunchResolver: ros1_launch_resolver.LaunchResolver;
+    private ros2LaunchResolver: ros2_launch_resolver.LaunchResolver;
 
     constructor() {
         this.configProvider = new ros_provider.RosDebugConfigurationProvider();
         this.attachResolver = new attach_resolver.AttachResolver();
-        this.launchResolver = new launch_resolver.LaunchResolver();
+        this.ros1LaunchResolver = new ros1_launch_resolver.LaunchResolver();
+        this.ros2LaunchResolver = new ros2_launch_resolver.LaunchResolver();
     }
 
     public async provideDebugConfigurations(folder: vscode.WorkspaceFolder | undefined, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration[]> {
@@ -27,7 +31,11 @@ class RosDebugManager implements vscode.DebugConfigurationProvider {
         if (config.request === "attach") {
             return this.attachResolver.resolveDebugConfigurationWithSubstitutedVariables(folder, config as requests.IAttachRequest, token);
         } else if (config.request === "launch") {
-            return this.launchResolver.resolveDebugConfigurationWithSubstitutedVariables(folder, config as requests.ILaunchRequest, token);
+            if ((typeof extension.env.ROS_VERSION === "undefined") || (extension.env.ROS_VERSION.trim() == "1")) {
+                return this.ros1LaunchResolver.resolveDebugConfigurationWithSubstitutedVariables(folder, config as requests.ILaunchRequest, token);
+            } else {
+                return this.ros2LaunchResolver.resolveDebugConfigurationWithSubstitutedVariables(folder, config as requests.ILaunchRequest, token);
+            }
         }
     }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -73,55 +73,62 @@ export enum Commands {
 }
 
 export async function activate(context: vscode.ExtensionContext) {
-    const reporter = telemetry.getReporter();
+    let init = vscode.window.withProgress({
+        location: vscode.ProgressLocation.Notification,
+        title: "ROS Extension Initializing...",
+        cancellable: false
+    }, async (progress, token) => {
+        const reporter = telemetry.getReporter();
+        extPath = context.extensionPath;
+        outputChannel = vscode_utils.createOutputChannel();
+        context.subscriptions.push(outputChannel);
 
-    extPath = context.extensionPath;
-    outputChannel = vscode_utils.createOutputChannel();
-    context.subscriptions.push(outputChannel);
-
-    // Activate if we're in a catkin workspace.
-    let buildToolDetected = await buildtool.determineBuildTool(vscode.workspace.rootPath);
-    if (!buildToolDetected) {
-        return;
-    }
-
-    // Activate components when the ROS env is changed.
-    context.subscriptions.push(onDidChangeEnv(activateEnvironment.bind(null, context)));
-
-    // Activate components which don't require the ROS env.
-    context.subscriptions.push(vscode.languages.registerDocumentFormattingEditProvider(
-        "cpp", new cpp_formatter.CppFormatter()
-    ));
-
-    URDFPreviewManager.INSTANCE.setContext(context);
-
-    // Source the environment, and re-source on config change.
-    let config = vscode_utils.getExtensionConfiguration();
-
-    context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(() => {
-        const updatedConfig = vscode_utils.getExtensionConfiguration();
-        const fields = Object.keys(config).filter(k => !(config[k] instanceof Function));
-        const changed = fields.some(key => updatedConfig[key] !== config[key]);
-
-        if (changed) {
-            sourceRosAndWorkspace();
+        // Activate if we're in a catkin workspace.
+        let buildToolDetected = await buildtool.determineBuildTool(vscode.workspace.rootPath);
+        if (!buildToolDetected) {
+            return;
         }
 
-        config = updatedConfig;
-    }));
+        // Activate components when the ROS env is changed.
+        context.subscriptions.push(onDidChangeEnv(activateEnvironment.bind(null, context)));
 
-    sourceRosAndWorkspace().then(() =>
-    {
-        vscode.window.registerWebviewPanelSerializer('urdfPreview', URDFPreviewManager.INSTANCE);
+        // Activate components which don't require the ROS env.
+        context.subscriptions.push(vscode.languages.registerDocumentFormattingEditProvider(
+            "cpp", new cpp_formatter.CppFormatter()
+        ));
+
+        URDFPreviewManager.INSTANCE.setContext(context);
+
+        // Source the environment, and re-source on config change.
+        let config = vscode_utils.getExtensionConfiguration();
+
+        context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(() => {
+            const updatedConfig = vscode_utils.getExtensionConfiguration();
+            const fields = Object.keys(config).filter(k => !(config[k] instanceof Function));
+            const changed = fields.some(key => updatedConfig[key] !== config[key]);
+
+            if (changed) {
+                sourceRosAndWorkspace();
+            }
+
+            config = updatedConfig;
+        }));
+
+        await sourceRosAndWorkspace().then(() =>
+        {
+            vscode.window.registerWebviewPanelSerializer('urdfPreview', URDFPreviewManager.INSTANCE);
+        });
+
+        reporter.sendTelemetryActivate();
+
+        return {
+            getBaseDir: () => baseDir,
+            getEnv: () => env,
+            onDidChangeEnv: (listener: () => any, thisArg: any) => onDidChangeEnv(listener, thisArg),
+        };
     });
 
-    reporter.sendTelemetryActivate();
-
-    return {
-        getBaseDir: () => baseDir,
-        getEnv: () => env,
-        onDidChangeEnv: (listener: () => any, thisArg: any) => onDidChangeEnv(listener, thisArg),
-    };
+    return await init;
 }
 
 export async function deactivate() {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -258,13 +258,17 @@ async function sourceRosAndWorkspace(): Promise<void> {
     }
 
     // Source the workspace setup over the top.
-    let workspaceDevelPath: string;
-    workspaceDevelPath = path.join(`${baseDir}`, "devel_isolated");
-    if (!await pfs.exists(workspaceDevelPath)) {
-        workspaceDevelPath = path.join(`${baseDir}`, "devel");
+    // TODO: we should test what's the build tool (catkin vs colcon).
+    let workspaceOverlayPath: string;
+    workspaceOverlayPath = path.join(`${baseDir}`, "devel_isolated");
+    if (!await pfs.exists(workspaceOverlayPath)) {
+        workspaceOverlayPath = path.join(`${baseDir}`, "devel");
+    }
+    if (!await pfs.exists(workspaceOverlayPath)) {
+        workspaceOverlayPath = path.join(`${baseDir}`, "install");
     }
     let wsSetupScript: string = path.format({
-        dir: workspaceDevelPath,
+        dir: workspaceOverlayPath,
         name: "setup",
         ext: setupScriptExt,
     });

--- a/src/ros/ros2/ros2.ts
+++ b/src/ros/ros2/ros2.ts
@@ -133,7 +133,7 @@ export class ROS2 implements ros.ROSApi {
         const packageBasePath = await packages[packageName]();
         const command: string = (process.platform === "win32") ?
             `where /r "${packageBasePath}" *launch.py` :
-            `find $(${packageBasePath}) -type f -name *launch.py`;
+            `find "${packageBasePath}" -type f -name *launch.py`;
 
         return new Promise((c, e) => child_process.exec(command, { env: this.env }, (err, out) => {
             err ? e(err) : c(out.trim().split(os.EOL));

--- a/src/ros/ros2/ros2.ts
+++ b/src/ros/ros2/ros2.ts
@@ -81,7 +81,10 @@ export class ROS2 implements ros.ROSApi {
 
     public async getWorkspaceIncludeDirs(workspaceDir: string): Promise<string[]> {
         const includes: string[] = [];
-        const opts = { env: this.env };
+        const opts = {
+            env: this.env,
+            cwd: workspaceDir
+        };
         const result = await promisifiedExec(`colcon list -p --base-paths "${workspaceDir}"`, opts);
 
         // error out if we see anything from stderr.


### PR DESCRIPTION
* Adding the initial ROS2 Launch Debug support. Current approach is to invoke ROS2 Launch System API and to mimic the entity traversal like [launch_service](https://github.com/ros2/launch/blob/master/launch/launch/launch_service.py).
