### PR TITLE
Adding error messages on exceptions for better diagnosis.

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -136,6 +136,14 @@ export async function deactivate() {
     await telemetry.clearReporter();
 }
 
+async function ensureErrorMessageOnException(callback: (...args: any[]) => any) {
+    try {
+        await callback();
+    } catch (err) {
+        vscode.window.showErrorMessage(err.message);
+    }
+}
+
 /**
  * Activates components which require a ROS env.
  */
@@ -167,40 +175,64 @@ function activateEnvironment(context: vscode.ExtensionContext) {
     // register plugin commands
     subscriptions.push(
         vscode.commands.registerCommand(Commands.CreateCatkinPackage, () => {
-            buildtool.BuildTool.createPackage(context);
+            ensureErrorMessageOnException(() => {
+                return buildtool.BuildTool.createPackage(context);
+            });
         }),
         vscode.commands.registerCommand(Commands.CreateTerminal, () => {
-            ros_utils.createTerminal(context);
+            ensureErrorMessageOnException(() => {
+                ros_utils.createTerminal(context);
+            });
         }),
         vscode.commands.registerCommand(Commands.GetDebugSettings, () => {
-            debug_utils.getDebugSettings(context);
+            ensureErrorMessageOnException(() => {
+                return debug_utils.getDebugSettings(context);
+            });
         }),
         vscode.commands.registerCommand(Commands.ShowCoreStatus, () => {
-            rosApi.showCoreMonitor();
+            ensureErrorMessageOnException(() => {
+                rosApi.showCoreMonitor();
+            });
         }),
         vscode.commands.registerCommand(Commands.StartRosCore, () => {
-            rosApi.startCore();
+            ensureErrorMessageOnException(() => {
+                rosApi.startCore();
+            });
         }),
         vscode.commands.registerCommand(Commands.TerminateRosCore, () => {
-            rosApi.stopCore();
+            ensureErrorMessageOnException(() => {
+                rosApi.stopCore();
+            });
         }),
         vscode.commands.registerCommand(Commands.UpdateCppProperties, () => {
-            ros_build_utils.updateCppProperties(context);
+            ensureErrorMessageOnException(() => {
+                return ros_build_utils.updateCppProperties(context);
+            });
         }),
         vscode.commands.registerCommand(Commands.UpdatePythonPath, () => {
-            ros_build_utils.updatePythonPath(context);
+            ensureErrorMessageOnException(() => {
+                ros_build_utils.updatePythonPath(context);
+            });
         }),
         vscode.commands.registerCommand(Commands.Rosrun, () => {
-            ros_cli.rosrun(context);
+            ensureErrorMessageOnException(() => {
+                return ros_cli.rosrun(context);
+            });
         }),
         vscode.commands.registerCommand(Commands.Roslaunch, () => {
-          ros_cli.roslaunch(context);
+            ensureErrorMessageOnException(() => {
+                return ros_cli.roslaunch(context);
+            });
         }),
         vscode.commands.registerCommand(Commands.Rosdep, () => {
-          rosApi.rosdep();
-      }),
-      vscode.commands.registerCommand(Commands.PreviewURDF, () => {
-            URDFPreviewManager.INSTANCE.preview(vscode.window.activeTextEditor.document.uri);
+            ensureErrorMessageOnException(() => {
+                rosApi.rosdep();
+            });
+        }),
+        vscode.commands.registerCommand(Commands.PreviewURDF, () => {
+            ensureErrorMessageOnException(() => {
+                URDFPreviewManager.INSTANCE.preview(vscode.window.activeTextEditor.document.uri);
+            });
         }),
         vscode.tasks.onDidEndTask((event: vscode.TaskEndEvent) => {
             if (buildtool.isROSBuildTask(event.execution.task)) {

--- a/src/ros/cli.ts
+++ b/src/ros/cli.ts
@@ -13,6 +13,9 @@ export async function rosrun(context: vscode.ExtensionContext) {
     reporter.sendTelemetryCommand(extension.Commands.Rosrun);
 
     const terminal = await preparerosrun();
+    if (!terminal) {
+        return;
+    }
     terminal.show();
 }
 
@@ -41,6 +44,9 @@ export async function roslaunch(context: vscode.ExtensionContext) {
     reporter.sendTelemetryCommand(extension.Commands.Roslaunch);
 
     let terminal = await prepareroslaunch();
+    if (!terminal) {
+        return;
+    }
     terminal.show();
 }
 

--- a/src/ros/ros2/ros2.ts
+++ b/src/ros/ros2/ros2.ts
@@ -133,10 +133,10 @@ export class ROS2 implements ros.ROSApi {
         const packageBasePath = await packages[packageName]();
         const command: string = (process.platform === "win32") ?
             `where /r "${packageBasePath}" *launch.py` :
-            `find "${packageBasePath}" -type f -name *launch.py`;
+            `find -L "${packageBasePath}" -type f -name *launch.py`;
 
         return new Promise((c, e) => child_process.exec(command, { env: this.env }, (err, out) => {
-            err ? e(err) : c(out.trim().split(os.EOL));
+            err ? e(new Error('No launch files are found.')) : c(out.trim().split(os.EOL));
         }));
     }
 


### PR DESCRIPTION
* Add error messages on exceptions for better diagnosis. It may help when people are reporting issues in future.
* And follow the symlink when searching for ROS2 launch files (we did the same thing for ROS1, and I am keeping the behavior consistent here.)