### PR TITLE
Use AMENT_PREFIX_PATH instead of COLCON_PREFIX_PATH. Closes #374

### DIFF
--- a/src/ros/ros2/ros2.ts
+++ b/src/ros/ros2/ros2.ts
@@ -64,8 +64,8 @@ export class ROS2 implements ros.ROSApi {
 
     public async getIncludeDirs(): Promise<string[]> {
         const prefixPaths: string[] = [];
-        if (this.env.COLCON_PREFIX_PATH) {
-            prefixPaths.push(...this.env.COLCON_PREFIX_PATH.split(path.delimiter));
+        if (this.env.AMENT_PREFIX_PATH) {
+            prefixPaths.push(...this.env.AMENT_PREFIX_PATH.split(path.delimiter));
         }
 
         const includeDirs: string[] = [];


### PR DESCRIPTION
Determine the includeDirs to set in .vscode/c_cpp_properties.json
from AMENT_PREFIX_PATH.

I checked with eloquent and foxy and it worked for both.


Closes #374 