### PR TITLE
Start ROSCore for launch debugging, if not running (ROS1)

### DIFF
--- a/src/ros/common/unknown-ros.ts
+++ b/src/ros/common/unknown-ros.ts
@@ -52,6 +52,11 @@ export class UnknownROS implements ros.ROSApi {
         return;
     }
 
+    public getCoreStatus(): Promise<boolean> {
+        console.error("Unknown ROS distro.");
+        return;
+    }
+
     public rosdep() {
       console.error("Unknown ROS distro.");
       return;

--- a/src/ros/ros.ts
+++ b/src/ros/ros.ts
@@ -57,6 +57,11 @@ export interface ROSApi {
     stopCore: () => void;
 
     /**
+     * Get ROS Core status
+     */
+    getCoreStatus: () => Promise<boolean>;
+
+    /**
      * Run ROSDep
      */
     rosdep: () => void;

--- a/src/ros/ros1/ros1.ts
+++ b/src/ros/ros1/ros1.ts
@@ -140,6 +140,10 @@ export class ROS1 implements ros.ROSApi {
         ros_core.stopCore(this.context, this._getXmlRpcApi());
     }
 
+    public getCoreStatus(): Promise<boolean> {
+        return this._getXmlRpcApi().check();
+    }
+
     public activateCoreMonitor(): vscode.Disposable {
         if (typeof this.env.ROS_MASTER_URI === "undefined") {
             return null;

--- a/src/ros/ros2/ros2.ts
+++ b/src/ros/ros2/ros2.ts
@@ -148,6 +148,11 @@ export class ROS2 implements ros.ROSApi {
         daemon.stopDaemon();
     }
 
+    public getCoreStatus(): Promise<boolean> {
+        // TODO: Core status checking not implemented for ROS2
+        return;
+    }
+
     public rosdep(): vscode.Terminal {
       const terminal = ros_utils.createTerminal(this.context);
       terminal.sendText(`rosdep install --from-paths src --ignore-src -r -y`);


### PR DESCRIPTION
Resolving #282 for ROS1, I chose option 2 for what was discussed with how to implement this feature. Since launch debugging needs to set rosparams, I found it more suitable to active the core at the beginning then monitor for it to become active. The core that is started will close when the VSCode Window is closed, same as having run the `ROS: Start Core` command manually. As I'm not familiar with ROS2, I set this feature to only work for ROS1.

Using the method I described in #330, I tested this implementation by using launch debugging on some rostests. Test cases includ asserting the values of rosparams, so I can verify that they are properly set.