### PR TITLE
Added command for running a ROS test file (ROS1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,9 +59,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "14.14.37",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.37.tgz",
-            "integrity": "sha512-XYmBiy+ohOR4Lh5jE379fV2IU+6Jn4g5qASinhitfyO71b/sCo6MKsMLF5tc7Zf2CE8hViVQyYSobJNke8OvUw==",
+            "version": "14.14.39",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.39.tgz",
+            "integrity": "sha512-Qipn7rfTxGEDqZiezH+wxqWYR8vcXq5LRpZrETD19Gs4o8LbklbmqotSUsMU+s5G3PJwMRDfNEYoxrcBwIxOuw==",
             "dev": true
         },
         "@types/shell-quote": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -689,9 +689,9 @@
             "dev": true
         },
         "js-yaml": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.0.0.tgz",
-            "integrity": "sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==",
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
             "requires": {
                 "argparse": "^2.0.1"
             },

--- a/package.json
+++ b/package.json
@@ -57,6 +57,11 @@
                 "category": "ROS"
             },
             {
+                "command": "ros.rostest",
+                "title": "Run a ROS test file (rostest)",
+                "category": "ROS"
+            },
+            {
                 "command": "ros.showCoreStatus",
                 "title": "Show Core Status",
                 "category": "ROS"

--- a/package.json
+++ b/package.json
@@ -348,7 +348,7 @@
         "test": "node ./out/src/test/runTest.js"
     },
     "dependencies": {
-        "js-yaml": "^4.0.0",
+        "js-yaml": "^4.1.0",
         "portfinder": "^1.0.28",
         "shell-quote": "^1.7.2",
         "sudo-prompt": "^9.2.1",

--- a/package.json
+++ b/package.json
@@ -359,7 +359,7 @@
     },
     "devDependencies": {
         "@types/js-yaml": "^4.0.0",
-        "@types/node": "^14.14.37",
+        "@types/node": "^14.14.39",
         "@types/shell-quote": "^1.7.0",
         "@types/tmp": "^0.2.0",
         "@types/xmlrpc": "^1.3.6",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -63,6 +63,7 @@ export enum Commands {
     GetDebugSettings = "ros.getDebugSettings",
     Rosrun = "ros.rosrun",
     Roslaunch = "ros.roslaunch",
+    Rostest = "ros.rostest",
     Rosdep = "ros.rosdep",
     ShowCoreStatus = "ros.showCoreStatus",
     StartRosCore = "ros.startCore",
@@ -222,6 +223,11 @@ function activateEnvironment(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand(Commands.Roslaunch, () => {
             ensureErrorMessageOnException(() => {
                 return ros_cli.roslaunch(context);
+            });
+        }),
+        vscode.commands.registerCommand(Commands.Rostest, () => {
+            ensureErrorMessageOnException(() => {
+                return ros_cli.rostest(context);
             });
         }),
         vscode.commands.registerCommand(Commands.Rosdep, () => {

--- a/src/ros/cli.ts
+++ b/src/ros/cli.ts
@@ -70,3 +70,35 @@ async function prepareroslaunch(): Promise<vscode.Terminal> {
     }
     return rosApi.activateRoslaunch(launchFilePath, argument);
 }
+
+export async function rostest(context: vscode.ExtensionContext) {
+    const reporter = telemetry.getReporter();
+    reporter.sendTelemetryCommand(extension.Commands.Rostest);
+
+    let terminal = await preparerostest();
+    if (!terminal) {
+        return;
+    }
+    terminal.show();
+}
+
+async function preparerostest(): Promise<vscode.Terminal> {
+    const packageName = await vscode.window.showQuickPick(rosApi.getPackageNames(), {
+        placeHolder: "Choose a package",
+    });
+    if (!packageName) {
+        return;
+    }
+    const launchFiles = (await rosApi.findPackageLaunchFiles(packageName)).concat(await rosApi.findPackageTestFiles(packageName));
+    const launchFileBasenames = launchFiles.map((filename) => path.basename(filename));
+    let target = await vscode.window.showQuickPick(launchFileBasenames, { placeHolder: "Choose a launch file" });
+    const launchFilePath = launchFiles[launchFileBasenames.indexOf(target)];
+    if (!launchFilePath) {
+        return;
+    }
+    let argument = await vscode.window.showInputBox({ placeHolder: "Enter any extra arguments" });
+    if (argument == undefined) {
+        return;
+    }
+    return rosApi.activateRostest(launchFilePath, argument);
+}

--- a/src/ros/common/unknown-ros.ts
+++ b/src/ros/common/unknown-ros.ts
@@ -42,6 +42,11 @@ export class UnknownROS implements ros.ROSApi {
         return;
     }
 
+    public findPackageTestFiles(packageName: string): Promise<string[]> {
+        console.error("Unknown ROS distro.");
+        return;
+    }
+
     public startCore() {
         console.error("Unknown ROS distro.");
         return;
@@ -73,6 +78,11 @@ export class UnknownROS implements ros.ROSApi {
     }
 
     public activateRoslaunch(launchFilepath: string, argument: string): vscode.Terminal {
+        console.error("Unknown ROS distro.");
+        return;
+    }
+    
+    public activateRostest(launchFilepath: string, argument: string): vscode.Terminal {
         console.error("Unknown ROS distro.");
         return;
     }

--- a/src/ros/ros.ts
+++ b/src/ros/ros.ts
@@ -47,6 +47,12 @@ export interface ROSApi {
     findPackageLaunchFiles: (packageName: string) => Promise<string[]>;
 
     /**
+     * list all .test files inside a package
+     * @param packageName 
+     */
+    findPackageTestFiles: (packageName: string) => Promise<string[]>;
+
+    /**
      * Start ROS Core
      */
     startCore: () => void;
@@ -80,6 +86,11 @@ export interface ROSApi {
      * Activate a terminal for roslaunch.
      */
     activateRoslaunch: (launchFilepath: string, argument: string) => vscode.Terminal;
+
+    /**
+     * Activate a terminal for rostest.
+     */
+    activateRostest: (launchFilepath: string, argument: string) => vscode.Terminal;
 }
 
 const ros1Api: ROSApi = new ros1.ROS1();

--- a/src/ros/ros1/ros1.ts
+++ b/src/ros/ros1/ros1.ts
@@ -126,6 +126,20 @@ export class ROS1 implements ros.ROSApi {
         }));
     }
 
+    public findPackageTestFiles(packageName: string): Promise<string[]> {
+        let command: string;
+        if (process.platform === "win32") {
+            return this._findPackageFiles(packageName, `--share`, `*.test`);
+        } else {
+            const dirs = `catkin_find --without-underlays --share '${packageName}'`;
+            command = `find -L $(${dirs}) -type f -name *.test`;
+        }
+        
+        return new Promise((c, e) => child_process.exec(command, { env: this.env }, (err, out) => {
+            err ? e(err) : c(out.trim().split(os.EOL));
+        }));
+    }
+
     public startCore() {
         if (typeof this.env.ROS_MASTER_URI === "undefined") {
             return;
@@ -172,6 +186,13 @@ export class ROS1 implements ros.ROSApi {
       const terminal = ros_utils.createTerminal(this.context);
         this.setTerminalEnv(terminal,this.env);
         terminal.sendText(`roslaunch ${launchFilepath} ${argument}`);
+        return terminal;
+    }
+
+    public activateRostest(launchFilepath: string, argument: string): vscode.Terminal {
+      const terminal = ros_utils.createTerminal(this.context);
+        this.setTerminalEnv(terminal,this.env);
+        terminal.sendText(`rostest ${launchFilepath} ${argument}`);
         return terminal;
     }
 

--- a/src/ros/ros2/ros2.ts
+++ b/src/ros/ros2/ros2.ts
@@ -140,6 +140,13 @@ export class ROS2 implements ros.ROSApi {
         }));
     }
 
+    public async findPackageTestFiles(packageName: string): Promise<string[]> {
+        // TODO: ROS2 rostest equivalent not implemented yet
+        return new Promise((resolve, reject) => {
+            resolve([]);
+        });
+    }
+
     public async startCore() {
         daemon.startDaemon();
     }
@@ -174,5 +181,10 @@ export class ROS2 implements ros.ROSApi {
       const terminal = ros_utils.createTerminal(this.context);
         terminal.sendText(`ros2 launch ${launchFilepath} ${argument}`);
         return terminal;
+    }
+
+    public activateRostest(launchFilepath: string, argument: string): vscode.Terminal {
+        console.error("ROS2 rostest equivalent not implemented yet");
+        return;
     }
 }


### PR DESCRIPTION
While exploring #330, I added a command for running rostest files as part of broader support for rostest. Since it seems debugging support is already working, I decided to submit this feature independently. As I'm not familiar with ROS2, this is implemented for just ROS1.