### PR TITLE
Fix lighting in URDF Preview

### DIFF
--- a/templates/preview.html
+++ b/templates/preview.html
@@ -124,8 +124,13 @@ function applyURDF(urdfText) {
         height : urdf.clientHeight,
         background : '#00000000',
         alpha : 0.001,
-        antialias : true
+        antialias : true,
+        intensity : 0.1
       });
+      // Add a dominant hemisphere light for even lighting
+      const hemiLight = new THREE.HemisphereLight(0xffffff, 0x444444, 0.8);
+      hemiLight.position.set(0, 0, 10);
+      window.viewer.addObject(hemiLight);
 
       // Add a grid.
       window.viewer.addObject(new ROS3D.Grid());


### PR DESCRIPTION
Simply added a hemisphere light to better show features of URDF from all sides. The default ros viewer object includes a directional light that doesn't show the back side of the URDF nicely.

Before:
![image](https://user-images.githubusercontent.com/47291559/121987589-e1405e00-cdec-11eb-9218-5ace83190513.png)
After:
![image](https://user-images.githubusercontent.com/47291559/121987622-f1f0d400-cdec-11eb-8d81-df241df7c1b6.png)
