### PR TITLE
ignore 'screen size is bogus' ps command error

### DIFF
--- a/src/debugger/process-picker/utils.ts
+++ b/src/debugger/process-picker/utils.ts
@@ -16,7 +16,7 @@ export function execChildProcess(process: string, workingDirectory: string): Pro
                 return;
             }
 
-            if (stderr && stderr.length > 0) {
+            if (stderr && stderr.length > 0 && !stderr.includes('screen size is bogus')) {
                 reject(new Error(stderr));
                 return;
             }


### PR DESCRIPTION
This implementing a fix similar to https://github.com/microsoft/vscode/pull/104277/commits/fc2eb524e1a1a3aa6960e05a82377e36c70b4190 and other plugins that use 'ps'.