### PR TITLE
Use default cpp browse database filepath

### DIFF
--- a/src/ros/build-env-utils.ts
+++ b/src/ros/build-env-utils.ts
@@ -61,7 +61,7 @@ async function updateCppPropertiesInternal(): Promise<void> {
         configurations: [
             {
                 browse: {
-                    databaseFilename: "${workspaceFolder}/.vscode/browse.vc.db",
+                    databaseFilename: "${default}",
                     limitSymbolsToIncludedHeaders: false,
                 },
                 includePath: includes,


### PR DESCRIPTION
Use the default workspace storage directory (i.e.  ~/.config/Code/User/workspaceStorage/${workspace ID}/) instead of ${workspaceFolder}/.vscode to avoid performance issues / crashes caused by frequent writes to the .vscode directory which is being watched

Setting browse.databaseFile to an empty string will also instruct vs code to use the default workspace storage directory, but using ${default} has the added benefit that the "C_Cpp.default.browse.databaseFilename" entry in settings.json will be honored if present. 

Ref https://code.visualstudio.com/docs/cpp/customize-default-settings-cpp
Ref https://code.visualstudio.com/docs/cpp/c-cpp-properties-schema-reference