### PR TITLE
fix: #724 handle ROS_DOMAIN_ID

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "vscode-ros",
-    "version": "0.8.2",
+    "version": "0.8.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/src/ros/ros2/ros2-monitor.ts
+++ b/src/ros/ros2/ros2-monitor.ts
@@ -10,6 +10,7 @@ import * as telemetry from "../../telemetry-helper";
 
 function getDaemonPort() {
     let basePort: number = 11511;
+    basePort += Number(process.env.ROS_DOMAIN_ID) || 0
     return basePort;
 }
 


### PR DESCRIPTION
Fixed a problem that prevented connection to daemon if ROS_DOMAIN_ID was set in the environment variable.

closes: #724

before

https://user-images.githubusercontent.com/16977736/170816687-79efa91c-4559-4bff-b4ff-7526c71bfc74.mp4


after

https://user-images.githubusercontent.com/16977736/170816694-ea76e938-7587-4127-a211-2206cde1e903.mp4

