### PR TITLE
Rename the python autocomplete paths

### DIFF
--- a/src/ros/build-env-utils.ts
+++ b/src/ros/build-env-utils.ts
@@ -9,7 +9,7 @@ import * as pfs from "../promise-fs";
 import * as telemetry from "../telemetry-helper";
 import { rosApi } from "./ros";
 
-const PYTHON_AUTOCOMPLETE_PATHS = "python.autoComplete.extraPaths";
+const PYTHON_AUTOCOMPLETE_PATHS = "python.analysis.extraPaths";
 
 /**
  * Creates config files which don't exist.


### PR DESCRIPTION
Noticed while creating a dev container environment for ROS that the settings that are auto-created by the extension are wrong. I have renamed them here to match the current python language server settings https://code.visualstudio.com/docs/python/settings-reference#_python-language-server-settings