### PR TITLE
Update attach.js to enable pretty-printing for "ros attach" mode

### DIFF
--- a/src/debugger/configuration/resolvers/attach.ts
+++ b/src/debugger/configuration/resolvers/attach.ts
@@ -70,6 +70,13 @@ export class AttachResolver implements vscode.DebugConfigurationProvider {
                     request: "attach",
                     program: config.commandLine,
                     processId: config.processId,
+                    setupCommands: [
+                        {
+                            text: "-enable-pretty-printing",
+                            description: "Enable pretty-printing for gdb",
+                            ignoreFailures: true
+                        }
+                    ]
                 };
                 debugConfig = cppdbgAttachConfig;
             }


### PR DESCRIPTION
Add setupCommands of "-enable-pretty-printing" to show the value of C++ STL containers when in "ros attach" mode.