### PR TITLE
Feature/debug ROS 2 launch files

### DIFF
--- a/package.json
+++ b/package.json
@@ -189,6 +189,31 @@
                             }
                         }
                     },
+                    "debug_launch": {
+                        "required": [
+                            "target"
+                        ],
+                        "properties": {
+                            "target": {
+                                "type": "string",
+                                "description": "Absolute path to launch file",
+                                "default": ""
+                            },
+                            "arguments": {
+                                "type": "array",
+                                "description": "Arguments for the roslaunch or ros2 launch command",
+                                "default": []
+                            },
+                            "env": {
+                                "type": "object",
+                                "description": "Environment variables defined as a key value pair. Property ends up being the Environment Variable and the value of the property ends up being the value of the Env Variable.",
+                                "default": {},
+                                "additionalProperties": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
                     "attach": {
                         "properties": {
                             "runtime": {

--- a/src/debugger/configuration/providers/ros.ts
+++ b/src/debugger/configuration/providers/ros.ts
@@ -11,12 +11,13 @@ export class RosDebugConfigurationProvider implements vscode.DebugConfigurationP
         folder: vscode.WorkspaceFolder | undefined,
         token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration[]> {
         const type = await vscode.window.showQuickPick(
-            ["ROS: Launch", "ROS: Attach"], { placeHolder: "Choose a request type" });
+            ["ROS: Launch", "ROS: Debug Launch File", "ROS: Attach"], { placeHolder: "Choose a request type" });
         if (!type) {
             return [];
         }
 
         switch (type) {
+            case "ROS: Debug Launch File":
             case "ROS: Launch": {
                 const packageName = await vscode.window.showQuickPick(rosApi.getPackageNames(), {
                     placeHolder: "Choose a package",
@@ -32,13 +33,23 @@ export class RosDebugConfigurationProvider implements vscode.DebugConfigurationP
                 if (!launchFilePath) {
                     return [];
                 }
-                return [{
-                    name: "ROS: Launch",
-                    request: "launch",
-                    target: `${launchFilePath}`,
-                    launch: ["rviz", "gz", "gzclient", "gzserver"],
-                    type: "ros",
-                }];
+
+                if (type === "ROS: Debug Launch File") {
+                    return [{
+                        name: type,
+                        request: "debug_launch",
+                        target: `${launchFilePath}`,
+                        type: "ros",
+                    }];
+                } else {
+                    return [{
+                        name: type,
+                        request: "launch",
+                        target: `${launchFilePath}`,
+                        launch: ["rviz", "gz", "gzclient", "gzserver"],
+                        type: "ros",
+                    }];
+                }
             }
             case "ROS: Attach": {
                 return [{

--- a/src/debugger/configuration/resolvers/ros2/debug_launch.ts
+++ b/src/debugger/configuration/resolvers/ros2/debug_launch.ts
@@ -1,0 +1,87 @@
+// Copyright (c) Andrew Short. All rights reserved.
+// Licensed under the MIT License.
+
+import * as child_process from "child_process";
+import * as fs from "fs";
+import * as yaml from "js-yaml";
+import * as os from "os";
+import * as path from "path";
+import * as readline from "readline";
+import * as shell_quote from "shell-quote";
+import * as tmp from "tmp";
+import * as util from "util";
+import * as vscode from "vscode";
+
+import * as extension from "../../../../extension";
+import * as requests from "../../../requests";
+import * as utils from "../../../utils";
+import { rosApi } from "../../../../ros/ros";
+
+const promisifiedExec = util.promisify(child_process.exec);
+
+interface ILaunchRequest {
+    nodeName: string;
+    executable: string;
+    arguments: string[];
+    cwd: string;
+    env: { [key: string]: string };
+    symbolSearchPath?: string;
+    additionalSOLibSearchPath?: string;
+    sourceFileMap?: { [key: string]: string };
+    launch?: string[];    // Scripts or executables to just launch without attaching a debugger
+    attachDebugger?: string[];    // If specified, Scripts or executables to debug; otherwise attaches to everything not ignored
+}
+
+function getExtensionFilePath(extensionFile: string): string {
+    return path.resolve(extension.extPath, extensionFile);
+}
+
+export class LaunchResolver implements vscode.DebugConfigurationProvider {
+    // tslint:disable-next-line: max-line-length
+    public async resolveDebugConfigurationWithSubstitutedVariables(folder: vscode.WorkspaceFolder | undefined, config: requests.ILaunchRequest, token?: vscode.CancellationToken) {
+        if (!path.isAbsolute(config.target)) {
+            throw new Error("Launch request requires an absolute path as target.");
+        }
+        else if (path.extname(config.target) !== ".py" && path.extname(config.target) !== ".xml") {
+            throw new Error("Launch request requires an extension '.py' or '.xml' as target.");
+        }
+
+        const rosExecOptions: child_process.ExecOptions = {
+            env: {
+                ...await extension.resolvedEnv(),
+                ...config.env,
+            },
+        };
+
+        console.log("Executing dumper with the following environment:");
+        console.log(rosExecOptions.env);
+
+        let ros2_launch_dumper = getExtensionFilePath(path.join("assets", "scripts", "ros2_launch_dumper.py"));
+
+        let args = [config.target]
+        if (config.arguments) {
+            for (let arg of config.arguments) {
+                args.push(`"${arg}"`);
+            }
+        }
+
+        const pythonLaunchConfig: IPythonLaunchConfiguration = {
+            name: ros2_launch_dumper,
+            type: "python",
+            request: "launch",
+            program: ros2_launch_dumper,
+            args: args,
+            env: rosExecOptions.env,
+            stopOnEntry: true,
+            justMyCode: false,
+        };
+
+        const launched = await vscode.debug.startDebugging(undefined, pythonLaunchConfig);
+        if (!launched) {
+            throw (new Error(`Failed to start debug session!`));
+        }
+
+        // Return null as we have spawned new debug requests
+        return null;
+    }
+}

--- a/src/debugger/configuration/resolvers/ros2/debug_launch.ts
+++ b/src/debugger/configuration/resolvers/ros2/debug_launch.ts
@@ -53,8 +53,8 @@ export class LaunchResolver implements vscode.DebugConfigurationProvider {
             },
         };
 
-        console.log("Executing dumper with the following environment:");
-        console.log(rosExecOptions.env);
+        extension.outputChannel.appendLine("Executing dumper with the following environment:");
+        extension.outputChannel.appendLine(JSON.stringify(rosExecOptions.env, null, 2));
 
         let ros2_launch_dumper = getExtensionFilePath(path.join("assets", "scripts", "ros2_launch_dumper.py"));
 


### PR DESCRIPTION
Implements ROS 2 Launch File debugging!
With this change, you can put breakpoints in a ROS 2 launch file, and have it break.

> NOTE: This change currently only implements the debugging of the file itself - not the launched ROS nodes. That's coming soon.

https://github.com/ms-iot/vscode-ros/issues/567
https://github.com/ms-iot/vscode-ros/issues/710