### PR TITLE
Fix ros.isolateEnvironment type

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ For team-managed projects (like this one), even if you have the access to make c
 After creating a fork of a repository, make sure to [configure a remote][git_configure_remote] first so the fork can sync up with the remote repository. For example, when working on a fork from this repository, do this first:
 
 ```batch
-git add upstream https://github.com/ms-iot/vscode-ros
+git remote add upstream https://github.com/ms-iot/vscode-ros
 ```
 
 *Note: the remote name does not need to be `upstream`, we are just using `upstream` as an example*

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
                     "description": "ROS workspace setup script. Overrides ros.distro."
                 },
                 "ros.isolateEnvironment": {
-                    "type": "bool",
+                    "type": "boolean",
                     "default": false,
                     "description": "Specify if the extension should not capture the environment VSCode is running in to pass to child processes."
                 },


### PR DESCRIPTION
Update `package.json` to use the proper JSON type name for a boolean: "bool" -> "boolean". This fixes a minor bug where `devcontainer.json` complains about the input value no matter what you put, because it can't return a "bool", only a "boolean".

Before:
![Screenshot from 2025-05-29 15-12-07](https://github.com/user-attachments/assets/73119544-f3be-46fd-9db6-39ac7166cf52)

After:
![Screenshot from 2025-05-29 15-44-09](https://github.com/user-attachments/assets/9a643419-a20a-497a-92df-a5c27b383515)
